### PR TITLE
mainwindow: Reduce tube selector to font 8

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -2425,6 +2425,11 @@ background-color:rgb(0, 0, 0);
              <height>40</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select tube model in database&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>


### PR DESCRIPTION
It became hard to read the long entries in the tube selector pull
down list because the centre text was replaced with ... as the font
was too big.

Therefore, reduce the font from 9 to 8 so the whole text can be read.

Signed-off-by: Dean <skullandbones99@gmail.com>