### PR TITLE
Bug: Fix failure to check home directory path exists

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -148,6 +148,14 @@ MainWindow::MainWindow(QWidget *parent) :
     //appDir = QCoreApplication.applicationDirPath()
     uTmaxDir = QDir::homePath();
     uTmaxDir.append("/uTmax_files/");
+    qDebug() << "Home directory:" << uTmaxDir;
+    QDir dir(uTmaxDir);
+    if(!dir.exists())
+    {
+        qDebug() << "ERROR: Home directory does not exist:" << uTmaxDir;
+        std::exit(EXIT_FAILURE);
+    }
+
     dataFileName = uTmaxDir;
     dataFileName.append("data.csv");
     ReadDataFile();


### PR DESCRIPTION
The mainwindow constructor defines the path to where the tube data
file and the calibration file are located but fails to check the
path exists.

Without the check, an attempt to write a new calibration file
silently fails.

Therefore, add a check to ensure the path to the data files exists
otherwise exit with an error message.

In addition, add some debug.

Signed-off-by: Dean Jenkins <skullandbones99@gmail.com>