### PR TITLE
Bug: Crash when cancelling data.csv file dialog

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -60,7 +60,7 @@ public:
     QString dataFileName;
     QString calFileName;
     void ReadCalibration();
-    void ReadDataFile();
+    bool ReadDataFile();
     ~MainWindow();
 
     void SaveCalFile();


### PR DESCRIPTION
If no "data.csv" file exists then a file dialog window is
opened to select the .csv file which contains the Thermionic
Valve / tube data. However, if the "cancel" option is clicked on
then a crash occurs.

Analysis found that the NULL QString test for the selected
file was not working which allowed the code to think that a file
had been selected when in fact the QString was set to NULL by
the returning file dialog due to the cancel operation.

A crash occurred because ReadDataFile() thought that it had
read in the data when in fact it had read no data.

Also it is noted that the program exit did not work because
the ReadDataFile() was executing within the mainwindow
constructor.

A partial solution is to use QString() to create the string
and to use isNULL() to test for a NULL QString. Then to return
false so that the mainwindow constructor could implement error
handling. However, std::exit() seems to cause a SIGSEGV so
a defect is still present and so a better solution is needed in
the future.

In addition, some data filename debug was added.

Signed-off-by: Dean Jenkins <skullandbones99@gmail.com>