### PR TITLE
mainwindow: Add checks to accessing calibration file

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -59,7 +59,7 @@ public:
     calData_t calData;
     QString dataFileName;
     QString calFileName;
-    void ReadCalibration();
+    bool ReadCalibration();
     bool ReadDataFile();
     ~MainWindow();
 


### PR DESCRIPTION
Writing and reading the calibration file has insufficient checks.
Therefore, add checks and debug to assist with diagnosis.

Move the 2 adc_scale lines inside ReadCalibration() because the
adc_scale values are dependent on the calibration information.

Signed-off-by: Dean Jenkins <skullandbones99@gmail.com>