### PR TITLE
mainwindow: Move file reading and serial port init to main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,31 @@ int main(int argc, char *argv[])
     QApplication a(argc, argv);
 
     MainWindow w;
+
+    w.uTmaxDir = QDir::homePath();
+    w.uTmaxDir.append("/uTmax_files/");
+    qDebug() << "Home directory:" << w.uTmaxDir;
+    QDir dir(w.uTmaxDir);
+    if(!dir.exists())
+    {
+        qDebug() << "ERROR: Home directory does not exist:" << w.uTmaxDir;
+        std::exit(EXIT_FAILURE);
+    }
+
+    // Read the default tube data file or ask for the file
+    w.dataFileName = w.uTmaxDir;
+    w.dataFileName.append("data.csv");
+    if (!w.ReadDataFile())
+        std::exit(EXIT_FAILURE);
+
+    // Read the calibration file or create a fresh file
+    w.calFileName = w.uTmaxDir;
+    w.calFileName.append("cal.txt");
+    if (!w.ReadCalibration())
+        std::exit(EXIT_FAILURE);
+
+    w.SerialPortDiscovery();
+
     w.show();
     
     return a.exec();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -143,32 +143,6 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->Tabs->setCurrentIndex(0);
     //
     optimizer = new dr_optimize();
-
-    //get paths and define file names
-    //appDir = QCoreApplication.applicationDirPath()
-    uTmaxDir = QDir::homePath();
-    uTmaxDir.append("/uTmax_files/");
-    qDebug() << "Home directory:" << uTmaxDir;
-    QDir dir(uTmaxDir);
-    if(!dir.exists())
-    {
-        qDebug() << "ERROR: Home directory does not exist:" << uTmaxDir;
-        std::exit(EXIT_FAILURE);
-    }
-
-    // Read the default tube data file or ask for the file
-    dataFileName = uTmaxDir;
-    dataFileName.append("data.csv");
-    if (!ReadDataFile())
-        std::exit(EXIT_FAILURE);
-
-    // Read the calibration file or create a fresh file
-    calFileName = uTmaxDir;
-    calFileName.append("cal.txt");
-    if (!ReadCalibration())
-        std::exit(EXIT_FAILURE);
-
-    SerialPortDiscovery();
 }
 
 MainWindow::~MainWindow()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -61,6 +61,7 @@ public:
     QString calFileName;
     bool ReadCalibration();
     bool ReadDataFile();
+    void SerialPortDiscovery();
     ~MainWindow();
 
     void SaveCalFile();
@@ -143,6 +144,8 @@ public:
     QList<QSerialPortInfo> serPortInfo;
     QString comport;
     void OpenComPort(const QString *);
+    QString uTmaxDir;
+
 
 
 public slots:
@@ -185,7 +188,6 @@ private:
     Ui::MainWindow *ui;
     void PenUpdate();
     void updateLcdsWithModel();
-    void SerialPortDiscovery();
     void updateSweepGreying();
     void updateTubeGreying();
     void CreateTestVectors();
@@ -196,7 +198,6 @@ private:
                     Sweep_set, Sweep_adc, Idle, wait_adc,
                     hold_ack, hold, heat_done,HeatOff};
     Status_t status;
-    QString uTmaxDir;
     int startSweep;
     int VsStep;
     int VgStep;


### PR DESCRIPTION
The constructor of mainwindow was reading the data.csv which
can fail. Unfortunately, a constructor cannot return an error
code and it is unwise to exit the program from within a constructor.
Therefore, move the reading of the data.csv file into the main
function of main.cpp.

Also reading and writing the calibration file can fail so move
that as well.

In addion move the serial port initialisation into main() to
make it clearer.

Signed-off-by: Dean Jenkins <skullandbones99@gmail.com>