### PR TITLE
Rework the serial port initialisation

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -148,9 +148,17 @@ MainWindow::MainWindow(QWidget *parent) :
 MainWindow::~MainWindow()
 {
     delete optimizer;
+    if (timer) {
+        qDebug() << "~MainWindow: Disconnecting timer";
+        disconnect(timer, SIGNAL(timeout()), this, SLOT(RxData()));
+        delete timer;
+    }
     //Close open port
-    if (portInUse->isOpen()  ) {
+    if (portInUse && portInUse->isOpen()) {
+        qDebug() << "~MainWindow: Disconnecting serial port";
+        disconnect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         portInUse->close();
+        delete portInUse;
     }
     delete ui;
 }
@@ -166,7 +174,6 @@ void MainWindow::SerialPortDiscovery()
     portInUse->setStopBits(QSerialPort::OneStop);
     portInUse->setFlowControl(QSerialPort::NoFlowControl);
     //10 bits????
-    connect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
 
     //get a list of ports
     serPortInfo = QSerialPortInfo::availablePorts();
@@ -192,6 +199,7 @@ void MainWindow::OpenComPort(const QString *portName)
     qDebug() <<"MainWindow::OpenComPort";
     //Close open port
     if (portInUse->isOpen()) {
+        disconnect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         qDebug() << "Closing Port:" << portInUse->portName();
         portInUse->close();
     }
@@ -202,6 +210,7 @@ void MainWindow::OpenComPort(const QString *portName)
     QString msg;
     if ( portInUse->open(QIODevice::ReadWrite))
     {
+        connect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         msg = QString("Port %1 opened").arg(comport);
         SaveCalFile(); //Update cal file with new port info
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -171,18 +171,19 @@ void MainWindow::SerialPortDiscovery()
     //get a list of ports
     serPortInfo = QSerialPortInfo::availablePorts();
     bool found = false;
+    qDebug() << "Requested serial port:" << comport;
     foreach (QSerialPortInfo port, serPortInfo) {
-        qDebug() << "SerialPortDiscovery: comport=" << comport <<  "available=" << port.portName();
-        if (comport.contains(port.portName()) and port.portName()!="") {
+        if (port.portName().isEmpty()) continue;
+        qDebug() << "Available serial port:" << port.portName();
+        if (!found && comport.contains(port.portName())) {
             found = true;
-            break;
+            qDebug() << "Using serial port:" << comport;
+            OpenComPort(&comport);
         }
     }
-    if (found) {
-        OpenComPort(&comport);
-    }
-    else  {
-        ui->statusBar->showMessage("The requested COM port was not found, try a different one.");
+    if (!found) {
+        qDebug() << "ERROR: Requested serial port:" << comport << "not found";
+        ui->statusBar->showMessage("The requested serial port was not found, try a different one.");
     }
 }
 


### PR DESCRIPTION
Allow all the available serial ports to be shown because this helps with diagnosis.

Ensure that the serial port signals and slots are only connected when the serial port is in the open state.

When the mainwindow destructor runs, check whether the portInUse and timer objects exist before destroying the objects.