### PR TITLE
Rework writing the calibration file

### DIFF
--- a/src/debug_dialog.cpp
+++ b/src/debug_dialog.cpp
@@ -142,13 +142,13 @@ void debug_dialog::UpdateComSel()
     }
     openPortEn=true;
     QString comport = mw->serPortInfo.at(0).portName();
-    if (i==1) mw->OpenComPort(&comport);
+    if (i == 1) mw->OpenComPort(&comport, true);
 }
 
 
 void debug_dialog::on_ComSel_currentIndexChanged(const QString &arg1)
 {
-   if (openPortEn) mw->OpenComPort(&arg1);
+    if (openPortEn) mw->OpenComPort(&arg1, true);
 }
 
 void debug_dialog::on_OK_clicked()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -185,7 +185,7 @@ void MainWindow::SerialPortDiscovery()
         if (!found && comport.contains(port.portName())) {
             found = true;
             qDebug() << "Using serial port:" << comport;
-            OpenComPort(&comport);
+            OpenComPort(&comport, false);
         }
     }
     if (!found) {
@@ -194,7 +194,7 @@ void MainWindow::SerialPortDiscovery()
     }
 }
 
-void MainWindow::OpenComPort(const QString *portName)
+void MainWindow::OpenComPort(const QString *portName, bool updateCalFile)
 {
     qDebug() <<"MainWindow::OpenComPort";
     //Close open port
@@ -212,7 +212,8 @@ void MainWindow::OpenComPort(const QString *portName)
     {
         connect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         msg = QString("Port %1 opened").arg(comport);
-        SaveCalFile(); //Update cal file with new port info
+        if(updateCalFile)
+            SaveCalFile(); //Update cal file with new port info
     }
     else
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1349,68 +1349,68 @@ int MainWindow::GetVf(float v)
 // Calibration File Management
 bool MainWindow::ReadCalibration()
 {
-    //Check to see if the cal file exists
-    QFile datafile(calFileName);
-    qDebug() << "Default calibration filename:" << calFileName;
-    if (! datafile.exists())
+    // Start with the default calibration values
+    // Default to the first serial port (if present)
+    QList<QSerialPortInfo> serPortInfo = QSerialPortInfo::availablePorts();
+    if (serPortInfo.count() > 0 && !serPortInfo.at(0).portName().isEmpty())
     {
-        //It doesn't exist so set up default values and create a file
-        if (!datafile.open(QIODevice::WriteOnly | QIODevice::Text))
-        {
-            qDebug() << "ERROR: failed to open for writing:" << calFileName;
-            return(false);
-        }
-        QTextStream calFile(&datafile);
-        calFile << "COM=COM1\n";
-        calFile << "Va=1.0\n";
-        calFile << "Vs=1.0\n";
-        calFile << "Ia=1.0\n";
-        calFile << "Is=1.0\n";
-        calFile << "Vsu=1.0\n";
-        calFile << "Vg1=1.0\n";
-        calFile << "Vg4=1.0\n";
-        calFile << "Vg40=1.0\n";
-        calFile << "Vg40=1.0\n";
-        calFile << "Vn=1.0\n";
-        calFile << "RaVal=6800\n";
-        calFile << "VaMax=300\n";
-        calFile << "IaMax=200\n";
-        calFile << "IsMax=200\n";
-        calFile << "VgMax=50\n";
-        calFile << ";Define pen number,color RGB, and width\n";
-        int r,g,b,w,h,s,v;
-        for(int i=0; i<16; i++) {
-            h = (360*(i % 16))/16;
-            s = 200;
-            v = 240-100*(i/16);
-            r = QColor::fromHsv(h,s,v,255).red() ;
-            g = QColor::fromHsv(h,s,v,255).green() ;
-            b = QColor::fromHsv(h,s,v,255).blue() ;
-            calFile << "PenNRGBWS="<< i << "," << r << "," << g << "," << b << "," << 2 << "\n";
-        }
-        calFile.flush();
-        datafile.close();
-        qDebug() << "ReadCalibration: Created new cal file" << calFileName;
+        // Use the first available serial port
+        comport = serPortInfo.at(0).portName();
     }
-    //Initialize a Pen List-
-    int r,g,b,w,h,s,v;
+    else
+    {
+        // Otherwise indicate no serial port
+        comport = "none";
+    }
+
+    // These are the calibrations values including comport.
+    calData.VaVal = 1.0;
+    calData.VsVal = 1.0;
+    calData.IaVal = 1.0;
+    calData.IsVal = 1.0;
+    calData.VsuVal = 1.0;
+    calData.Vg1Val = 1.0;
+    calData.Vg4Val = 1.0;
+    calData.Vg40Val = 1.0;
+    calData.VnVal = 1.0;
+    calData.RaVal = 6800;
+    calData.VaMax = 300;
+    calData.IaMax = 200;
+    calData.IsMax = 200;
+    calData.VgMax = 50;
+
+    // Initialise the Pen List colours
+    int r, g, b, h, s, v;
     QPen grPen;
-    for(int i=0; i<16; i++) {
-        h = (360*(i % 16))/16;
+    for (int i = 0; i < 16; i++)
+    {
+        h = (360 * (i % 16)) / 16;
         s = 200;
-        v = 240-100*(i/16);
-        r = QColor::fromHsv(h,s,v,255).red() ;
-        g = QColor::fromHsv(h,s,v,255).green() ;
-        b = QColor::fromHsv(h,s,v,255).blue() ;
-        grPen.setColor(QColor::fromRgb(r,g,b));
+        v = 240 - 100 * (i / 16);
+        r = QColor::fromHsv(h, s, v, 255).red();
+        g = QColor::fromHsv(h, s, v, 255).green();
+        b = QColor::fromHsv(h, s, v, 255).blue();
+        grPen.setColor(QColor::fromRgb(r, g, b));
         grPen.setWidthF(2);
         penList->append(grPen);
     }
-    //Create a black pen to fill unused entries
+
+    // Check to see if the calibration file exists
+    QFile datafile(calFileName);
+    qDebug() << "Default calibration filename:" << calFileName;
+    if (!datafile.exists())
+    {
+        // Create a default calibration file
+        if (!SaveCalFile())
+            return(false);
+    }
+
+    // Create a black pen to fill unused entries
     QPen black;
     black.setColor(QColor::fromRgb(0,0,0,255));
     black.setWidthF(2);
-    //Open the cal.txt file
+
+    // Read the calibration file which will replace the default settings in memory
     if (!datafile.open(QIODevice::ReadOnly | QIODevice::Text))
     {
         qDebug() << "ERROR: failed to open for reading:" << calFileName;
@@ -1468,14 +1468,14 @@ bool MainWindow::ReadCalibration()
     return(true);
 }
 
-void MainWindow::SaveCalFile()
+bool MainWindow::SaveCalFile()
 {
     qDebug () << "SaveCalFile...";
+    bool ret = false;
     QFile datafile(calFileName);
     if (datafile.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QTextStream calFile(&datafile);
-        if (portInUse!=NULL) calFile << "COM=" << portInUse->portName() << "\n";
-        else calFile << "COM=COM1\n";
+        calFile << "COM=" << comport << "\n";
         calFile << "Va=" << calData.VaVal << "\n";
         calFile << "Vs=" << calData.VsVal << "\n";
         calFile << "Ia=" << calData.IaVal << "\n";
@@ -1502,8 +1502,11 @@ void MainWindow::SaveCalFile()
         }
         calFile.flush();
         datafile.close();
+        ret = true;
         //qDebug() << "SaveCalFile: ...updated cal file";
     } else qDebug() << "Save Cal file failed";
+
+    return(ret);
 }
 
 //------------------------------------------------------

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -143,7 +143,7 @@ public:
     QSerialPort * portInUse;
     QList<QSerialPortInfo> serPortInfo;
     QString comport;
-    void OpenComPort(const QString *);
+    void OpenComPort(const QString *, bool updateCalFile);
     QString uTmaxDir;
 
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -64,7 +64,7 @@ public:
     void SerialPortDiscovery();
     ~MainWindow();
 
-    void SaveCalFile();
+    bool SaveCalFile();
     void GetReal();
     void DataSaveDialog_clicked(const QString &);
 


### PR DESCRIPTION
It was noted that the initial default calibration file was
using a slightly different format to SaveCalFile().
The default wrote in float format "1.0" but SaveCalFile()
wrote "1". Also the calData.Vg40Val entry was duplicated in the
default write case.

Therefore, simplify ReadCalibration() by:

a) start with the default calibration information
b) if no calibration file exists use SaveCalFile() to save it
c) read the existing calibration file

This solution ensures there is a single function to read and
a single function to write the calibration information so
removes duplicate code and makes the code less error prone.

In addition, remove the serial port check code from SaveCalFile()
because comport will have the name of the user selected serial port
or the default first serial port name or "none" if no serial ports
are available. This means the check was unnecessary.


It is unnecessary to update the calibration file every time
the program starts because the calibration file has been read
before opening the serial port. Therefore, no information changed
so rewriting the file with the same information is redundant.

The solution is to add a flag updateCalFile parameter to
OpenComPort() to control whether the calibration file is
written to when opening the serial port.

Modify SerialPortDiscovery() to not save the calibration file.
