### PR TITLE
Cleanup of serial port selection

### DIFF
--- a/src/debug_dialog.cpp
+++ b/src/debug_dialog.cpp
@@ -123,26 +123,46 @@ void debug_dialog::UpdateVals()
 
 void debug_dialog::UpdateComSel()
 {
-    //Scrub current List
-    openPortEn =false;
+    // Scrub current List
+    openPortEn = false;
     ui->ComSel->clear();
 
-    int i=0;
-    foreach (QSerialPortInfo port, mw->serPortInfo) {
+    int portEntries = 0;
+    int portNonEntries = 0;
+    int firstEntry = -1;
+    int firstNonEntry = -1;
+    bool currentSerialPort = false;
+    foreach (QSerialPortInfo port, mw->serPortInfo)
+    {
         if (!port.portName().isNull())
         {
             ui->ComSel->addItem(port.portName());
-            qDebug() << "setting serPortInfo, comport:" << port.portName() << mw->comport;
+            qDebug() << "UpdateComSel(): serPortInfo:" << port.portName() << " comport:" << mw->comport;
             if (port.portName().contains(mw->comport))
             {
-                ui->ComSel->setCurrentIndex(i);
+                ui->ComSel->setCurrentIndex(portNonEntries);
+                currentSerialPort = true;
             }
-            i++;
+            if (firstEntry == -1)
+            {
+                firstEntry = portEntries;
+                firstNonEntry = portNonEntries;
+            }
+            portNonEntries++;
         }
+        portEntries++;
     }
-    openPortEn=true;
-    QString comport = mw->serPortInfo.at(0).portName();
-    if (i == 1) mw->OpenComPort(&comport, true);
+
+    // If the requested serial port is not found then select the first entry in the list (if available),
+    // then open it, and update the calibration file with the new serial port name.
+    if (!currentSerialPort && firstEntry != -1)
+    {
+        QString comport = mw->serPortInfo.at(firstEntry).portName();
+        qDebug() << "UpdateComSel(): Selecting the default serial port:" << comport;
+        ui->ComSel->setCurrentIndex(firstNonEntry);
+        mw->OpenComPort(&comport, true);
+    }
+    openPortEn = true;
 }
 
 

--- a/src/debug_dialog.cpp
+++ b/src/debug_dialog.cpp
@@ -164,6 +164,10 @@ void debug_dialog::UpdateComSel()
         ui->ComSel->setCurrentIndex(firstNonEntry);
         mw->OpenComPort(&comport, true);
     }
+
+    // If the list of serial ports is empty then ensure the serial port is closed
+    if (!portNonEntries) mw->CloseComPort();
+
     openPortEn = true;
 }
 

--- a/src/debug_dialog.cpp
+++ b/src/debug_dialog.cpp
@@ -127,14 +127,16 @@ void debug_dialog::UpdateComSel()
     openPortEn = false;
     ui->ComSel->clear();
 
+    // Get a list of serial ports
+    QList<QSerialPortInfo> serPortInfo = QSerialPortInfo::availablePorts();
     int portEntries = 0;
     int portNonEntries = 0;
     int firstEntry = -1;
     int firstNonEntry = -1;
     bool currentSerialPort = false;
-    foreach (QSerialPortInfo port, mw->serPortInfo)
+    foreach (QSerialPortInfo port, serPortInfo)
     {
-        if (!port.portName().isNull())
+        if (!port.portName().isEmpty())
         {
             ui->ComSel->addItem(port.portName());
             qDebug() << "UpdateComSel(): serPortInfo:" << port.portName() << " comport:" << mw->comport;
@@ -157,7 +159,7 @@ void debug_dialog::UpdateComSel()
     // then open it, and update the calibration file with the new serial port name.
     if (!currentSerialPort && firstEntry != -1)
     {
-        QString comport = mw->serPortInfo.at(firstEntry).portName();
+        QString comport = serPortInfo.at(firstEntry).portName();
         qDebug() << "UpdateComSel(): Selecting the default serial port:" << comport;
         ui->ComSel->setCurrentIndex(firstNonEntry);
         mw->OpenComPort(&comport, true);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1352,11 +1352,23 @@ bool MainWindow::ReadCalibration()
 {
     // Start with the default calibration values
     // Default to the first serial port (if present)
+    int i = 0;
+    int firstEntry = -1;
     QList<QSerialPortInfo> serPortInfo = QSerialPortInfo::availablePorts();
-    if (serPortInfo.count() > 0 && !serPortInfo.at(0).portName().isEmpty())
+    foreach (QSerialPortInfo port, serPortInfo)
+    {
+        if (!port.portName().isEmpty())
+        {
+            if (firstEntry == -1) firstEntry = i;
+            break;
+        }
+        i++;
+    }
+
+    if (firstEntry != -1)
     {
         // Use the first available serial port
-        comport = serPortInfo.at(0).portName();
+        comport = serPortInfo.at(firstEntry).portName();
     }
     else
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -175,8 +175,8 @@ void MainWindow::SerialPortDiscovery()
     portInUse->setFlowControl(QSerialPort::NoFlowControl);
     //10 bits????
 
-    //get a list of ports
-    serPortInfo = QSerialPortInfo::availablePorts();
+    // Get a list of serial ports
+    QList<QSerialPortInfo> serPortInfo = QSerialPortInfo::availablePorts();
     bool found = false;
     qDebug() << "Requested serial port:" << comport;
     foreach (QSerialPortInfo port, serPortInfo) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -197,22 +197,25 @@ void MainWindow::SerialPortDiscovery()
 void MainWindow::OpenComPort(const QString *portName, bool updateCalFile)
 {
     qDebug() <<"MainWindow::OpenComPort";
-    //Close open port
-    if (portInUse->isOpen()) {
+
+    // Close open port
+    if (portInUse->isOpen())
+    {
         disconnect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         qDebug() << "Closing Port:" << portInUse->portName();
         portInUse->close();
     }
-    //Open requested port
+
+    // Open requested port
     comport = *portName;
     portInUse->setPortName(comport);
-    qDebug() << "MainWindow::OpenComPort"  << portInUse->portName();
+    qDebug() << "MainWindow::OpenComPort" << portInUse->portName();
     QString msg;
-    if ( portInUse->open(QIODevice::ReadWrite))
+    if (portInUse->open(QIODevice::ReadWrite))
     {
         connect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         msg = QString("Port %1 opened").arg(comport);
-        if(updateCalFile)
+        if (updateCalFile)
             SaveCalFile(); //Update cal file with new port info
     }
     else
@@ -221,8 +224,9 @@ void MainWindow::OpenComPort(const QString *portName, bool updateCalFile)
     }
     ui->statusBar->showMessage(msg);
 
-    //Start RxData Timer
-    if (timer==NULL) {
+    // Start RxData Timer
+    if (timer==NULL)
+    {
         timer = new QTimer(this);
         connect(timer, SIGNAL(timeout()), this, SLOT(RxData()));
         ui->statusBar->showMessage("Starting up...");

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -139,9 +139,7 @@ public:
     float VgNow;
     float VfNow;
     //QextSerialPort * portInUse;
-    //QList<QextPortInfo> serPortInfo;
     QSerialPort * portInUse;
-    QList<QSerialPortInfo> serPortInfo;
     QString comport;
     void OpenComPort(const QString *, bool updateCalFile);
     QString uTmaxDir;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -138,12 +138,10 @@ public:
     float VsNow;
     float VgNow;
     float VfNow;
-    //QextSerialPort * portInUse;
-    QSerialPort * portInUse;
     QString comport;
     bool OpenComPort(const QString *, bool updateCalFile);
     QString uTmaxDir;
-
+    bool CloseComPort();
 
 
 public slots:
@@ -290,6 +288,7 @@ private:
     QList<PlotTabWidget*> plotTabs;
     bool ignoreIndexChange;
 
+    QSerialPort *portInUse;
 
 };
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -141,7 +141,7 @@ public:
     //QextSerialPort * portInUse;
     QSerialPort * portInUse;
     QString comport;
-    void OpenComPort(const QString *, bool updateCalFile);
+    bool OpenComPort(const QString *, bool updateCalFile);
     QString uTmaxDir;
 
 


### PR DESCRIPTION
Allow the list of available serial ports to be recreated when the debug_dialog window is opened. This allows new USB to Ethernet adaptors to be listed without restarting the program.

If the serial port identified by the calibration file fails to open then allow the debug_dialog window to automatically select the first available serial port and update the calibration file with the new serial port name.

Create a CloseComPort() function to counter the OpenComPort() function. This allows the serial port to be closed independently of opening.