### PR TITLE
Add functions to manage start and stop of the protocol engine plus operation requests

### DIFF
--- a/src/debug_dialog.cpp
+++ b/src/debug_dialog.cpp
@@ -184,11 +184,12 @@ void debug_dialog::on_OK_clicked()
 
 void debug_dialog::on_Ping_clicked()
 {
-    mw->sendADC=true;
+    // Button is actually "Read ADC"
+    mw->RequestOperation((Operation_t) ReadADC);
 }
 
 
 void debug_dialog::on_pushPing_clicked()
 {
-    mw->sendPing=true;
+    mw->RequestOperation((Operation_t) Ping);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -277,37 +277,34 @@ void MainWindow::readData()
     if (portInUse) RxString.append(portInUse->readAll());
 }
 
-int MainWindow::RxPkt(int len, QByteArray * cmd, QByteArray * response)
+int MainWindow::RxPkt(int len, QByteArray *cmd, QByteArray *response)
 {
-    //if (portInUse->bytesAvailable()>0)   RxString.append(portInUse->readAll());
     if (len==0) return RXCONTINUE;
-    //qDebug() << "RxPkt: cmd is: len=" << len << "cmd=" << cmd->constData();
     timeout--;
-    if (timeout ==0) {
+    if (timeout == 0)
+    {
         RxString.clear();
         response->clear();
         qDebug() << "RxPkt: TIMEOUT";
         return RXTIMEOUT;
     }
-    //if (RxString.length()>0) qDebug() << "RxPkt: RxString is:" << RxString << "len is now::" << RxString.length();
-    if (RxString.length()>=len) {
-        if ( (cmd->length()==0) || RxString.startsWith(* cmd) ) {
-            * response = RxString.mid(cmd->length(),len);
-            //qDebug() << "RxPkt: reply OK, response" << response->constData();
+    if (RxString.length() >= len)
+    {
+        if ((cmd->length() == 0) || RxString.startsWith(*cmd))
+        {
+            *response = RxString.mid(cmd->length(), len);
             RxString.clear();
-            if (len==18) echoString = TxString;
-            if (len==38+18) {
+            if (len == 18) echoString = TxString;
+            if (len == 38 + 18)
+            {
                 echoString = TxString;
                 statusString = response->constData();
             }
-            //if (len==18+18) {
-            //    echoString = TxString;
-            //    statusString = response->constData();
-            //}
             cmd->clear();
-            return RXSUCCESS ;
+            return RXSUCCESS;
         }
-        else {
+        else
+        {
             qDebug() << "RxPkt: reply invalid=" << RxString;
             RxString.clear();
             response->clear();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -335,6 +335,7 @@ void MainWindow::RxData()
 
     if (sendADC == true)
     {
+        qDebug() << "RxData: Action sendADC";
         cmd = TxString = "500000000000000000";
         rxLen = TxString.length() + 38;
         heat = 0;
@@ -348,6 +349,7 @@ void MainWindow::RxData()
 
     if (sendPing == true)
     {
+        qDebug() << "RxData: Action sendPing";
         cmd = TxString = "300000000000000000";
         rxLen = TxString.length();
         heat = 0;
@@ -373,6 +375,7 @@ void MainWindow::RxData()
     // Check for timeout
     if (RxCode == RXTIMEOUT && timer_on)
     {
+        qDebug() << "RxData: Action RxCode RXTIMEOUT";
         ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
         TxString = "300000000000000000";
         response.clear();
@@ -387,6 +390,7 @@ void MainWindow::RxData()
     // Check for invalid rsponse
     if (RxCode == RXINVALID)
     {
+        qDebug() << "RxData: Action RxCode RXINVALID";
         ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
         response.clear();
         rxLen = 0;
@@ -398,6 +402,8 @@ void MainWindow::RxData()
     // ---------------------------------------------------
     // Main state machine
     // Check state
+    qDebug() << "RxData: status:" << status << ":" << status_name[status];
+
     switch (status)
     {
         case Idle:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -317,7 +317,7 @@ int MainWindow::RxPkt(int len, QByteArray * cmd, QByteArray * response)
     return RXCONTINUE;
 }
 //---------------------------------------------
-//The main control process
+// The main control process
 void MainWindow::RxData()
 {
     static int time;
@@ -333,190 +333,209 @@ void MainWindow::RxData()
     static QByteArray response;
     static int distime;
 
-    if (sendADC==true)
+    if (sendADC == true)
     {
-        cmd = TxString="500000000000000000";
-        rxLen = TxString.length()+38;
-        heat=0;
+        cmd = TxString = "500000000000000000";
+        rxLen = TxString.length() + 38;
+        heat = 0;
         sendSer();
-        sendADC=false;
-        status=wait_adc;
+        sendADC = false;
+        status = wait_adc;
         timeout = PING_TIMEOUT;
-        timer_on=true;
+        timer_on = true;
         return;
     }
-    if (sendPing==true)
+
+    if (sendPing == true)
     {
-        cmd = TxString="300000000000000000";
+        cmd = TxString = "300000000000000000";
         rxLen = TxString.length();
-        heat=0;
+        heat = 0;
         sendSer();
-        sendPing=false;
-        status=WaitPing;
+        sendPing = false;
+        status = WaitPing;
         timeout = PING_TIMEOUT;
-        timer_on=true;
+        timer_on = true;
         return;
     }
+
     // ---------------------------------------------------
-    // sanity check that the port is still OK
+    // Sanity check that the port is still OK
     if (!portInUse || !portInUse->isOpen())
     {
         ui->statusBar->showMessage("COM port was closed, exit and restart.");
         return;
     }
+
     // ---------------------------------------------------
     // Check for the uTracer response
     int RxCode = RxPkt(rxLen, &cmd, &response);
     // Check for timeout
-    if (RxCode==RXTIMEOUT && timer_on)
+    if (RxCode == RXTIMEOUT && timer_on)
     {
         ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
-        TxString="300000000000000000";
+        TxString = "300000000000000000";
         response.clear();
         cmd = TxString;
         rxLen = TxString.length();
         sendSer();
-        timer_on= false;
+        timer_on = false;
         status = Idle;
         return;
     }
-    //Check for invalid rsponse
-    if (RxCode==RXINVALID)
+
+    // Check for invalid rsponse
+    if (RxCode == RXINVALID)
     {
         ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
         response.clear();
         rxLen = 0;
-        timer_on= false;
+        timer_on = false;
         status = Idle;
         return;
     }
+
     // ---------------------------------------------------
-    //Main state machine
-    //Check state
-    switch (status) {
-        case Idle: {
+    // Main state machine
+    // Check state
+    switch (status)
+    {
+        case Idle:
+        {
             rxLen = 0;
-            timer_on=false;
-            time=0;
-            //ui->statusBar->showMessage("Ready");
-            if (startSweep>0)
+            timer_on = false;
+            time = 0;
+
+            if (startSweep > 0)
             {
-                startSweep-=1;
+                startSweep -= 1;
                 StoreData(false); //Init data store
-                VsStep=0;
-                VgStep=0;
-                VaStep=0;
-                curve=0;
-                if (heat!=HEAT_CNT_MAX) {
+                VsStep = 0;
+                VgStep = 0;
+                VaStep = 0;
+                curve = 0;
+
+                if (heat != HEAT_CNT_MAX)
+                {
                     ui->statusBar->showMessage("Heating setup");
                     status = Heating_wait00;
-                    heat=0;
+                    heat = 0;
                     ui->HeaterProg->setValue(1);
                 }
-                else {
+                else
+                {
                     ui->statusBar->showMessage("Sweep setup");
                     status = Sweep_set;
                     delay=options.Delay;
                 }
+
                 ui->CaptureProg->setValue(1);
-                TxString="0000000000";
+                TxString = "0000000000";
                 ::snprintf(buf, 3, "%02X", lim[options.Ilimit]);
-                TxString+=buf;
+                TxString += buf;
                 ::snprintf(buf, 3, "%02X", avg[options.AvgNum]);
-                TxString+=buf;
+                TxString += buf;
                 ::snprintf(buf, 3, "%02X", Ir[options.IsRange]);
-                TxString+=buf;
+                TxString += buf;
                 ::snprintf(buf, 3, "%02X", Ir[options.IaRange]);
-                TxString+=buf;
-                cmd =TxString;
-                rxLen=18;
+                TxString += buf;
+                cmd = TxString;
+                rxLen = 18;
                 sendSer();
-                timer_on=true;
+                timer_on = true;
                 timeout = PING_TIMEOUT;
             }
             break;
         }
-        case WaitPing: {
-            //qDebug()<<"WaitPing";
-            if (RxCode==RXSUCCESS) {
-                rxLen=0;
-                cmd="";
-                status=Idle;
+        case WaitPing:
+        {
+            if (RxCode == RXSUCCESS)
+            {
+                rxLen = 0;
+                cmd = "";
+                status = Idle;
                 ui->statusBar->showMessage("Ping OK");
-                timer_on=false;
+                timer_on = false;
                 timeout = PING_TIMEOUT;
-           }
-            break;
-        }
-        case wait_adc: {
-            //qDebug()<<"Wait_adc";
-            if (RxCode==RXSUCCESS) {
-                saveADCInfo(&response);
-                rxLen=0;
-                cmd="";
-                status=Idle;
-                ui->statusBar->showMessage("Ready");
-                timer_on=false;
-                timeout = PING_TIMEOUT;
-           }
-            break;
-        }
-        case Heating_wait00: {
-            //qDebug()<<"Heating_wait00";
-            if (RxCode==RXSUCCESS) {
-                ui->statusBar->showMessage("Heating, get ADC info");
-                status=Heating_wait_adc;
-                cmd = TxString="500000000000000000";
-                rxLen = TxString.length()+38;
-                sendSer();
-                timer_on=true;
-                timeout=PING_TIMEOUT;
             }
             break;
         }
-        case Heating_wait_adc: {
-            //qDebug()<<"Heating_wait_adc";
-            if (RxCode==RXSUCCESS) {
+        case wait_adc:
+        {
+            if (RxCode == RXSUCCESS)
+            {
+                saveADCInfo(&response);
+                rxLen = 0;
+                cmd = "";
+                status = Idle;
+                ui->statusBar->showMessage("Ready");
+                timer_on = false;
+                timeout = PING_TIMEOUT;
+            }
+            break;
+        }
+        case Heating_wait00:
+        {
+            if (RxCode == RXSUCCESS)
+            {
+                ui->statusBar->showMessage("Heating, get ADC info");
+                status = Heating_wait_adc;
+                cmd = TxString = "500000000000000000";
+                rxLen = TxString.length() + 38;
+                sendSer();
+                timer_on = true;
+                timeout = PING_TIMEOUT;
+            }
+            break;
+        }
+        case Heating_wait_adc:
+        {
+            if (RxCode == RXSUCCESS)
+            {
                 VgNow=ui->VgStart->text().toFloat();
                 saveADCInfo(&response);
-                heat=0;
-                status=Heating;
+                heat = 0;
+                status = Heating;
                 ui->statusBar->showMessage("Heating");
-                TxString="400000000000000000";
+                TxString = "400000000000000000";
                 rxLen = TxString.length();
                 cmd = TxString;
                 sendSer();
-                timer_on=true;
+                timer_on = true;
                 timeout = PING_TIMEOUT;
-                heat=1;
+                heat = 1;
             }
             break;
         }
-        case Heating: {
-            //qDebug()<<"Heating";
-            if (stop) {
+        case Heating:
+        {
+            if (stop)
+            {
                 stop = false;
-                status=HeatOff;
-                HV_Discharge_Timer =0;
+                status = HeatOff;
+                HV_Discharge_Timer = 0;
                 ui->HeaterProg->setValue(0);
                 ui->statusBar->showMessage("Heater off");
-                TxString="400000000000000000";
+                TxString = "400000000000000000";
                 cmd = TxString;
                 rxLen = TxString.length();
                 sendSer();
-                heat=0;
-                timeout =PING_TIMEOUT;
-                timer_on=true;
+                heat = 0;
+                timeout = PING_TIMEOUT;
+                timer_on = true;
             }
-            else if (RxCode==RXSUCCESS) {
-                if (heat<=HEAT_CNT_MAX) {
-                    if (startSweep > 0) {
-                        startSweep -=1;
+            else if (RxCode == RXSUCCESS)
+            {
+                if (heat <= HEAT_CNT_MAX)
+                {
+                    if (startSweep > 0)
+                    {
+                        startSweep -= 1;
                         heat = HEAT_CNT_MAX;
                     }
-                    ui->HeaterProg->setValue((100*heat)/HEAT_CNT_MAX);
+                    ui->HeaterProg->setValue((100 * heat) / HEAT_CNT_MAX);
                     VfADC = GetVf((float)heat);
-                    if (VfADC>1023) VfADC=1023;
+                    if (VfADC > 1023) VfADC = 1023;
                     ::snprintf(buf, 19, "40000000000000%04X", VfADC);
                     TxString = buf;
                     rxLen = TxString.length();
@@ -525,211 +544,215 @@ void MainWindow::RxData()
                     sendSer();
                     heat++;
                 }
-                else {
-                    //qDebug()<<"Heating Done";
+                else
+                {
                     ui->HeaterProg->setValue(100);
                     timeout = PING_TIMEOUT;
-                    status=heat_done;
-                    timer_on=false;
-                    rxLen=0;
-                    cmd="";
+                    status = heat_done;
+                    timer_on = false;
+                    rxLen = 0;
+                    cmd = "";
                 }
             }
             break;
         }
-        case heat_done: {
-            //qDebug()<<"Heat_done";
-            QString m = QString("Press 'start' when ready; heating for %1 secs").arg(time/1000);
-            time+=TIMER_SET;
+        case heat_done:
+        {
+            QString m = QString("Press 'start' when ready; heating for %1 secs").arg(time / 1000);
+            time += TIMER_SET;
             ui->statusBar->showMessage(m);
-            delay=options.Delay;
+            delay = options.Delay;
             if (stop)
             {
                 stop = false;
-                status=HeatOff;
-                HV_Discharge_Timer =0;
-                cmd=TxString="400000000000000000";
+                status = HeatOff;
+                HV_Discharge_Timer = 0;
+                cmd=TxString = "400000000000000000";
                 rxLen=TxString.length();
                 sendSer();
                 ui->CaptureProg->setValue(0);
-                timeout =PING_TIMEOUT;
-                timer_on=true;
+                timeout = PING_TIMEOUT;
+                timer_on = true;
             }
-            else if (startSweep>0 || time/1000==HEAT_WAIT_SECS) {
-                startSweep=0;
-                if (dataStore->length()>0) dataStore->clear();
-                rxLen=0;
-                cmd="";
+            else if (startSweep > 0 || time / 1000 == HEAT_WAIT_SECS)
+            {
+                startSweep = 0;
+                if (dataStore->length() > 0) dataStore->clear();
+                rxLen = 0;
+                cmd = "";
                 CreateTestVectors();
-                curve=0;
-                status=Sweep_set;
+                curve = 0;
+                status = Sweep_set;
             }
             break;
         }
-        case Sweep_set: {
+        case Sweep_set:
+        {
             if (stop)
             {
-                //qDebug() << "Sweep set(stop)";
                 stop = false;
-                status=HeatOff;
+                status = HeatOff;
                 float v = VaNow > VsNow ? VaNow : VsNow;
-                distime =(int)(DISTIME * v/400);
-                HV_Discharge_Timer =distime;
+                distime = (int)(DISTIME * v / 400);
+                HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
-                cmd = TxString="400000000000000000";
+                cmd = TxString = "400000000000000000";
                 rxLen = TxString.length();
                 sendSer();
                 ui->CaptureProg->setValue(0);
-                timeout =PING_TIMEOUT;
-                timer_on=true;
+                timeout = PING_TIMEOUT;
+                timer_on = true;
             }
-            else if (delay==0) {
-                //qDebug() << "Sweep set";
+            else if (delay == 0)
+            {
                 status=hold_ack;
                 ui->statusBar->showMessage("Sweep Measure");
                 VaNow = sweepList->at(curve).Va;
                 VsNow = sweepList->at(curve).Vs;
                 VgNow = sweepList->at(curve).Vg;
-                //qDebug() << "a=" << VaNow << "s=" << VsNow << "g=" << VgNow;
-                //qDebug() << "VaStep=" << VaStep << "VsStep=" << VsStep << "VgStep=" << VgStep;
-                VaADC = GetVa( VaNow );
-                VsADC = GetVs( VsNow );
-                VgADC = GetVg( VgNow );
+                VaADC = GetVa(VaNow);
+                VsADC = GetVs(VsNow);
+                VgADC = GetVg(VgNow);
                 VfADC = GetVf( HEAT_CNT_MAX );
-                status=Sweep_adc;
-                timeout=ADC_READ_TIMEOUT;
-                timer_on=true;
-                ::snprintf(buf,19,"10%04X%04X%04X%04X",VaADC,VsADC,VgADC,VfADC );
-                cmd = TxString=buf;
-                rxLen=TxString.length()+38;
+                status = Sweep_adc;
+                timeout = ADC_READ_TIMEOUT;
+                timer_on = true;
+                ::snprintf(buf, 19, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC );
+                cmd = TxString= buf;
+                rxLen= TxString.length() + 38;
                 sendSer();
             }
-            else {
+            else
+            {
                 ui->statusBar->showMessage("Sweep hold");
                 VaNow = sweepList->at(curve).Va;
                 VsNow = sweepList->at(curve).Vs;
                 VgNow = sweepList->at(curve).Vg;
-                if (VaNow>425 || VsNow>425) {
+                if (VaNow > 425 || VsNow > 425)
+                {
                     ui->statusBar->showMessage("Internal Error: Vaor Vs excessive");
                     stop = false;
-                    status=HeatOff;
+                    status = HeatOff;
                     float v = VaNow > VsNow ? VaNow : VsNow;
-                    distime =(int)(DISTIME * v/400);
-                    HV_Discharge_Timer =distime;
+                    distime = (int)(DISTIME * v / 400);
+                    HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
-                    TxString="400000000000000000";
+                    TxString = "400000000000000000";
                     cmd = TxString;
                     rxLen = TxString.length();
                     sendSer();
                     heat=0;
-                    timeout =PING_TIMEOUT;
-                    timer_on=true;
+                    timeout = PING_TIMEOUT;
+                    timer_on = true;
                     break;
                 }
-//                qDebug() << "a=" << VaNow << "s=" << VsNow << "g=" << VgNow;
-//                qDebug() << "VaStep=" << VaStep << "VsStep=" << VsStep << "VgStep=" << VgStep;
-                VaADC = GetVa( VaNow );
-                VsADC = GetVs( VsNow );
-                VgADC = GetVg( VgNow );
-                VfADC = GetVf( HEAT_CNT_MAX );
-                status=hold_ack;
-                timeout=ADC_READ_TIMEOUT + options.Delay;
-                timer_on=true;
-                sprintf(buf,"20%04X%04X%04X%04X",VaADC,VsADC,VgADC,VfADC );
-                cmd = TxString=buf;
-                rxLen=TxString.length();
+                VaADC = GetVa(VaNow);
+                VsADC = GetVs(VsNow);
+                VgADC = GetVg(VgNow);
+                VfADC = GetVf(HEAT_CNT_MAX);
+                status = hold_ack;
+                timeout = ADC_READ_TIMEOUT + options.Delay;
+                timer_on = true;
+                sprintf(buf, "20%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
+                cmd = TxString = buf;
+                rxLen = TxString.length();
                 sendSer();
             }
             break;
         }
-        case hold_ack: {
-            status=hold;
-            timer_on=false;
-            rxLen=0;
-            cmd="";
+        case hold_ack:
+        {
+            status = hold;
+            timer_on = false;
+            rxLen = 0;
+            cmd = "";
             break;
         }
-        case hold : {
+        case hold:
+        {
             if (stop)
             {
                 stop = false;
-                status=HeatOff;
+                status = HeatOff;
                 float v = VaNow > VsNow ? VaNow : VsNow;
-                distime =(int)(DISTIME * v/400);
-                HV_Discharge_Timer =distime;
+                distime = (int)(DISTIME * v / 400);
+                HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
-                TxString="400000000000000000";
+                TxString = "400000000000000000";
                 cmd = TxString;
                 rxLen = TxString.length();
                 sendSer();
-                heat=0;
-                timeout =PING_TIMEOUT;
-                timer_on=true;
+                heat = 0;
+                timeout = PING_TIMEOUT;
+                timer_on = true;
             }
-            else if (delay==0)
+            else if (delay == 0)
             {
-                status=Sweep_adc;
+                status = Sweep_adc;
                 ui->statusBar->showMessage("Sweep (set measurement parameters)");
-                //qDebug() << "a=" << VaNow << "s=" << VsNow << "g=" << VgNow;
-                //qDebug() << "VaStep=" << VaStep << "VsStep=" << VsStep << "VgStep=" << VgStep;
                 VaNow = sweepList->at(curve).Va;
                 VsNow = sweepList->at(curve).Vs;
                 VgNow = sweepList->at(curve).Vg;
-                if (VaNow>425 || VsNow>425) {
+                if (VaNow > 425 || VsNow > 425)
+                {
                     ui->statusBar->showMessage("Internal Error: Va or Vs excessive");
                     stop = false;
-                    status=HeatOff;
+                    status = HeatOff;
                     float v = VaNow > VsNow ? VaNow : VsNow;
-                    distime =(int)(DISTIME * v/400);
-                    HV_Discharge_Timer =distime;
+                    distime = (int)(DISTIME * v / 400);
+                    HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
-                    TxString="400000000000000000";
+                    TxString = "400000000000000000";
                     cmd = TxString;
                     rxLen = TxString.length();
                     sendSer();
-                    heat=0;
-                    timeout =PING_TIMEOUT;
-                    timer_on=true;
+                    heat = 0;
+                    timeout = PING_TIMEOUT;
+                    timer_on = true;
                     break;
                 }
 
-                VaADC = GetVa( VaNow );
-                VsADC = GetVs( VsNow );
-                VgADC = GetVg( VgNow );
-                VfADC = GetVf( HEAT_CNT_MAX );
-                timeout=ADC_READ_TIMEOUT;
-                timer_on=true;
-                sprintf(buf,"10%04X%04X%04X%04X",VaADC,VsADC,VgADC,VfADC );
-                cmd = TxString=buf;
-                rxLen = TxString.length()+38;
+                VaADC = GetVa(VaNow);
+                VsADC = GetVs(VsNow);
+                VgADC = GetVg(VgNow);
+                VfADC = GetVf(HEAT_CNT_MAX);
+                timeout = ADC_READ_TIMEOUT;
+                timer_on = true;
+                sprintf(buf, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
+                cmd = TxString = buf;
+                rxLen = TxString.length() + 38;
                 sendSer();
             }
-            else {
+            else
+            {
                 ui->statusBar->showMessage("Sweep (Holding)");
-                //qDebug() << "delay=" << delay;
                 delay--;
-                status=hold;
-                rxLen =0;
-                cmd ="";
+                status = hold;
+                rxLen = 0;
+                cmd = "";
             }
             break;
         }
-        case Sweep_adc: {
-            if (RxCode==RXSUCCESS) {
+        case Sweep_adc:
+        {
+            if (RxCode == RXSUCCESS)
+            {
                 //check current limit
                 saveADCInfo(&response);
                 StoreData(true); //Add to data store
-                if (response.mid(0,2)=="11") {
+                if (response.mid(0,2) == "11")
+                {
                     ui->statusBar->showMessage("WARNING: Current Limit Hit");
                     qDebug() << "Sweep_adc: Current Limit Hit";
-                    if (options.AbortOnLimit==true) {
+                    if (options.AbortOnLimit == true)
+                    {
                         qDebug() << "Sweep_adc: Current Limit Abort";
-                        status=HeatOff;
+                        status = HeatOff;
                         float v = VaNow > VsNow ? VaNow : VsNow;
-                        distime =(int)(DISTIME * v/400);
+                        distime =(int)(DISTIME * v / 400);
                         HV_Discharge_Timer =distime;
                         ui->CaptureProg->setValue(100);
-                        TxString="400000000000000000";
+                        TxString = "400000000000000000";
                         cmd = TxString;
                         rxLen = TxString.length();
                         sendSer();
@@ -737,41 +760,46 @@ void MainWindow::RxData()
                     }
                 }
                 curve++;
-                bool done=false;
-                if ( (power > tubeData.powerLim) && !ui->checkQuickTest->isChecked()) {
-                    while (!done) {
-                        if (sweepList->at(curve).Va >= VaNow) {
-                            results.Ia=-1; // mark as ignore
+                bool done = false;
+                if ((power > tubeData.powerLim) && !ui->checkQuickTest->isChecked())
+                {
+                    while (!done)
+                    {
+                        if (sweepList->at(curve).Va >= VaNow)
+                        {
+                            results.Ia = -1; // mark as ignore
                             dataStore->append(results);
                             curve++; //skip high power points
-                            if (curve == sweepList->length()) {
-                                done =true;
-                                if ( (dataStore->length()>5) && ui->TubeType->currentText()!=NONE) {
-                                        optimizer->Optimize(dataStore, ui->TubeType->currentIndex(), 1, VaSteps, VsSteps, VgSteps);
-                                        updateLcdsWithModel();
-                                        RePlot(dataStore);
+                            if (curve == sweepList->length())
+                            {
+                                done = true;
+                                if ((dataStore->length() > 5) && ui->TubeType->currentText() != NONE)
+                                {
+                                    optimizer->Optimize(dataStore, ui->TubeType->currentIndex(), 1, VaSteps, VsSteps, VgSteps);
+                                    updateLcdsWithModel();
+                                    RePlot(dataStore);
                                 }
                             }
                         }
-                        else done=true;
+                        else done = true;
 
                     }
                 }
-                if (curve < sweepList->length()) {
-                    int progress=(100*curve)/sweepList->length();
+                if (curve < sweepList->length())
+                {
+                    int progress = (100 * curve) / sweepList->length();
                     ui->CaptureProg->setValue(progress);
                     QString msg = QString("Sweep %1 % done").arg(progress);
                     ui->statusBar->showMessage(msg);
                     delay = options.Delay;
-                    //qDebug() << "From Sweep_adc to Sweep_set";
-                    status=Sweep_set;
-                    timeout=ADC_READ_TIMEOUT;
-                    rxLen=0;
-                    cmd="";
+                    status = Sweep_set;
+                    timeout = ADC_READ_TIMEOUT;
+                    rxLen = 0;
+                    cmd = "";
                 }
                 else
                 {
-                    if (startSweep>0) //skip re-heating
+                    if (startSweep > 0) //skip re-heating
                     {
                         status = heat_done;
                         ui->statusBar->showMessage("Sweep complete");
@@ -779,13 +807,13 @@ void MainWindow::RxData()
                     }
                     else
                     {
-                        status=HeatOff;
+                        status = HeatOff;
                         float v = VaNow > VsNow ? VaNow : VsNow;
-                        distime =(int)(DISTIME * v/400);
-                        HV_Discharge_Timer =distime;
+                        distime = (int)(DISTIME * v / 400);
+                        HV_Discharge_Timer = distime;
                         ui->statusBar->showMessage("Sweep complete");
                         ui->CaptureProg->setValue(100);
-                        TxString="400000000000000000";
+                        TxString = "400000000000000000";
                         cmd = TxString;
                         rxLen = TxString.length();
                         sendSer();
@@ -794,31 +822,34 @@ void MainWindow::RxData()
             }
             break;
         }
-        case HeatOff: {
-            //qDebug() << "HeatOff";
+        case HeatOff:
+        {
             if (HV_Discharge_Timer>0) HV_Discharge_Timer--;
-            if (HV_Discharge_Timer==(distime-1)) {
-                cmd  = TxString="300000000000000000";
+            if (HV_Discharge_Timer == (distime-1))
+            {
+                cmd = TxString = "300000000000000000";
                 rxLen = TxString.length();
                 sendSer();
-                heat=0;
+                heat = 0;
                 ui->HeaterProg->setValue(0);
-                timeout =PING_TIMEOUT;
-                if (ui->checkAutoNumber->isChecked()) {
+                timeout = PING_TIMEOUT;
+                if (ui->checkAutoNumber->isChecked())
+                {
                     if (!ui->checkQuickTest->isChecked()) on_actionSave_plot_triggered();
                     on_actionSave_Data_triggered();
                     int fn = ui->AutoNumber->text().toInt(&ok);
-                    ui->AutoNumber->setText(QString::number(fn+1));
+                    ui->AutoNumber->setText(QString::number(fn + 1));
                 }
-                timer_on=true;
+                timer_on = true;
 
-            } else if (HV_Discharge_Timer==0) {
+            } else if (HV_Discharge_Timer==0)
+            {
                 ui->statusBar->showMessage("Ready");
                 status=Idle;
             }
             else
             {
-                timeout =PING_TIMEOUT;
+                timeout = PING_TIMEOUT;
                 QString msg = QString("Countdown for HV to discharge: %1").arg(HV_Discharge_Timer);
                 ui->statusBar->showMessage(msg);
             }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -222,8 +222,8 @@ bool MainWindow::OpenComPort(const QString *portName, bool updateCalFile)
     }
     ui->statusBar->showMessage(msg);
 
-    // Start the machine
-    if (openResult) StartUpMachine();
+    // Probe for the uTracer being present
+    if (openResult) RequestOperation((Operation_t) Probe);
 
     return(openResult);
 }
@@ -243,16 +243,63 @@ bool MainWindow::CloseComPort()
     }
 }
 
+void MainWindow::RequestOperation(Operation_t ReqOperation)
+{
+    switch (ReqOperation)
+    {
+        case Stop:
+        {
+            qDebug() << "RequestOperation: Stop";
+            stop = true;
+            StartUpMachine();
+            break;
+        }
+        case Probe:
+        {
+            qDebug() << "RequestOperation: Probe";
+            ui->statusBar->showMessage("Starting up...");
+            sendADC = true;
+            StartUpMachine();
+            break;
+        }
+        case Ping:
+        {
+            qDebug() << "RequestOperation: Ping";
+            sendPing = true;
+            StartUpMachine();
+            break;
+        }
+        case ReadADC:
+        {
+            qDebug() << "RequestOperation: ReadADC";
+            sendADC = true;
+            StartUpMachine();
+            break;
+        }
+        case Start:
+        {
+            qDebug() << "RequestOperation: Start";
+            if (SetUpSweepParams())
+            {
+                startSweep += 1;
+                StartUpMachine();
+            }
+            break;
+        }
+        default:
+        {
+            qDebug() << "ERROR: RequestOperation: Unrecognised operation:" << ReqOperation;
+            break;
+        }
+    }
+}
+
 void MainWindow::StartUpMachine()
 {
     // Start up the machine
     if (!timer)
     {
         qDebug() << "StartUpMachine: Starting up the machine!";
-        ui->statusBar->showMessage("Starting up...");
-        timer_on = true;
-        timeout = PING_TIMEOUT;
-        sendADC = true;
         timer = new QTimer(this);
         connect(timer, SIGNAL(timeout()), this, SLOT(RxData()));
         timer->start(TIMER_SET);
@@ -447,6 +494,11 @@ void MainWindow::RxData()
                 sendSer();
                 timer_on = true;
                 timeout = PING_TIMEOUT;
+            }
+            else
+            {
+                // All operations completed so stop
+                StopTheMachine();
             }
             break;
         }
@@ -2314,10 +2366,9 @@ bool MainWindow::SetUpSweepParams() {
     return true;
 }
 
-void MainWindow::on_Start_clicked() {
-    if (!SetUpSweepParams()) return;
-
-    startSweep+=1;
+void MainWindow::on_Start_clicked()
+{
+    RequestOperation((Operation_t) Start);
 }
 void MainWindow::CreateTestVectors()
 {
@@ -2439,8 +2490,9 @@ void MainWindow::CreateTestVectors()
 void MainWindow::on_VsStart_editingFinished() {
 }
 
-void MainWindow::on_Stop_clicked() {
-    stop=true;
+void MainWindow::on_Stop_clicked()
+{
+    RequestOperation((Operation_t) Stop);
 }
 
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -150,6 +150,7 @@ public:
     void DataSaveDialog_clicked(const QString &);
     bool OpenComPort(const QString *, bool updateCalFile);
     bool CloseComPort();
+    void RequestOperation(Operation_t ReqOperation);
 
 public slots:
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -279,6 +279,8 @@ private:
     void DoPlot(plotInfo_t *  );
     void RePlot(QList<results_t> * );
     bool SaveTubeDataFile();
+    void StartUpMachine();
+    void StopTheMachine();
 
     QList<QPen> * penList;
     int RxPkt(int len, QByteArray * pCmd, QByteArray * pResponse);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -189,11 +189,14 @@ private:
     void CreateTestVectors();
     void ClearLCDs();
 
-
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
-                    hold_ack, hold, heat_done,HeatOff};
+                    hold_ack, hold, heat_done, HeatOff};
     Status_t status;
+    QString status_name[HeatOff + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
+                                        "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
+                                        "hold_ack", "hold", "heat_done", "HeatOff"};
+
     int startSweep;
     int VsStep;
     int VgStep;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -13,8 +13,6 @@
 
 
 #include <QMainWindow>
-//#include "../3rdparty/qextserialport-1.2rc/src/qextserialport.h"
-//#include "../3rdparty/qextserialport-1.2rc/src/qextserialenumerator.h"
 #include <QQueue>
 #include <QTimer>
 #include <QFile>
@@ -29,8 +27,9 @@
 #include <QtSerialPort/QSerialPortInfo>
 
 
-namespace Ui {
-class MainWindow;
+namespace Ui
+{
+    class MainWindow;
 }
 
 class MainWindow : public QMainWindow
@@ -38,7 +37,9 @@ class MainWindow : public QMainWindow
     Q_OBJECT
     
 public:
+    // Type and variable declarations
     explicit MainWindow(QWidget *parent = 0);
+
     struct calData_t
     {
         float VaVal;
@@ -55,18 +56,11 @@ public:
         float IaMax=200;
         float IsMax=200;
         float VgMax=-57;
-    } ;
+    };
+
     calData_t calData;
     QString dataFileName;
     QString calFileName;
-    bool ReadCalibration();
-    bool ReadDataFile();
-    void SerialPortDiscovery();
-    ~MainWindow();
-
-    bool SaveCalFile();
-    void GetReal();
-    void DataSaveDialog_clicked(const QString &);
 
     struct adc_data_t
     {
@@ -81,6 +75,7 @@ public:
         int Gain_a;
         int Gain_s;
     };
+
     // This holds the ADC data from uTracer
     adc_data_t adc_data;
 
@@ -103,9 +98,12 @@ public:
         float Gain_a;
         float Gain_s;
     };
+
     adc_scale_t adc_scale;  //the ADC scale factors
     adc_scale_t adc_real;   //the real version of the ADC readings
-    struct options_t {
+
+    struct options_t
+{
         int IaRange;
         int IsRange;
         int Delay;
@@ -114,6 +112,7 @@ public:
         bool AbortOnLimit;
         float VgScale;
     };
+
     options_t options;
 
     QByteArray TxString;
@@ -139,16 +138,20 @@ public:
     float VgNow;
     float VfNow;
     QString comport;
-    bool OpenComPort(const QString *, bool updateCalFile);
     QString uTmaxDir;
+
+    // Function protoypes
+    ~MainWindow();
+    bool ReadCalibration();
+    bool ReadDataFile();
+    void SerialPortDiscovery();
+    bool SaveCalFile();
+    void GetReal();
+    void DataSaveDialog_clicked(const QString &);
+    bool OpenComPort(const QString *, bool updateCalFile);
     bool CloseComPort();
 
-
 public slots:
-    //void onDeviceDiscovered(const QextPortInfo & );
-    //void onDeviceRemoved(const QextPortInfo & );
-    //TODO Update plot when this happens:
-    //void ErrorWeightClicked();
 
 
 private slots:
@@ -166,10 +169,7 @@ private slots:
     void on_Stop_clicked();
     void on_TubeType_currentIndexChanged(int index);
     void on_actionSave_Spice_Model_triggered();
-    //void on_plotDockWidget_dockLocationChanged(const Qt::DockWidgetArea &area);
-    //void on_plotDockWidget_topLevelChanged(bool topLevel);
     void on_actionRead_Data_triggered();
-    //void on_actionPreferences_triggered();
     void on_AutoPath_editingFinished();
     void on_AddType_clicked();
     void on_DeleteType_clicked();
@@ -177,17 +177,11 @@ private slots:
     void on_checkQuickTest_clicked();
     void on_Tabs_currentChanged(int index);
     void on_Tabs_tabCloseRequested(int index);
-
     void on_Browse_clicked();
 
 private:
+    // Type and variable declarations
     Ui::MainWindow *ui;
-    void PenUpdate();
-    void updateLcdsWithModel();
-    void updateSweepGreying();
-    void updateTubeGreying();
-    void CreateTestVectors();
-    void ClearLCDs();
 
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
@@ -206,24 +200,14 @@ private:
     bool stop;
     bool timer_on;
     int timeout;
-    QTimer * timer;
-    void saveADCInfo(QByteArray *);
-    int GetVa(float);
-    int GetVs(float);
-    int GetVg(float);
-    int GetVf(float);
+    QTimer *timer;
     bool ok;
     bool newMessage;
-    void sendSer();
     QByteArray RxString;
-    void StoreData(bool);
-    void SetUpPlot();
-    bool SetUpSweepParams();
     float Vdi;
     float power;
-    void UpdateTitle();
 
-    //test vector store
+    // Test vector store
     struct test_vector_t {
         float Va, Vs, Vg;
     };
@@ -231,7 +215,7 @@ private:
     test_vector_t test_vector;
     QList<test_vector_t> *sweepList;
 
-    //results store
+    // Results store
     results_t results;
     QList<results_t> *dataStore;
     QList<results_t> *refStore;
@@ -273,27 +257,44 @@ private:
         float EmmVg;
         float EmmIa;
     };
+
     tubeData_t tubeData;
     QList<tubeData_t> *tubeDataList;
 
     plotInfo_t plot1;
 
-    void LabelPins(tubeData_t);
-    void DoPlot(plotInfo_t *  );
-    void RePlot(QList<results_t> * );
-    bool SaveTubeDataFile();
-    void StartUpMachine();
-    void StopTheMachine();
-
-    QList<QPen> * penList;
-    int RxPkt(int len, QByteArray * pCmd, QByteArray * pResponse);
+    QList<QPen> *penList;
     QFile logFile;
-    dr_optimize * optimizer;
+    dr_optimize *optimizer;
 
     QList<PlotTabWidget*> plotTabs;
     bool ignoreIndexChange;
 
     QSerialPort *portInUse;
 
+    // Function protoypes
+    void PenUpdate();
+    void updateLcdsWithModel();
+    void updateSweepGreying();
+    void updateTubeGreying();
+    void CreateTestVectors();
+    void ClearLCDs();
+    void saveADCInfo(QByteArray *);
+    int GetVa(float);
+    int GetVs(float);
+    int GetVg(float);
+    int GetVf(float);
+    void sendSer();
+    void StoreData(bool);
+    void SetUpPlot();
+    bool SetUpSweepParams();
+    void UpdateTitle();
+    void LabelPins(tubeData_t);
+    void DoPlot(plotInfo_t *);
+    void RePlot(QList<results_t> *);
+    bool SaveTubeDataFile();
+    void StartUpMachine();
+    void StopTheMachine();
+    int RxPkt(int len, QByteArray *pCmd, QByteArray *pResponse);
 };
 #endif // MAINWINDOW_H

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -33,7 +33,8 @@ struct results_t
     float mu_b;
 };
 
-struct plotInfo_t {
+struct plotInfo_t
+{
     int VaSteps;
     int VsSteps;
     int VgSteps;
@@ -43,14 +44,20 @@ struct plotInfo_t {
     float VsEnd;
     float VgStart;
     float VgEnd;
-    QList<results_t> * dataSet;
+    QList<results_t> *dataSet;
     QString tube;
     QString type;
-    QList<QPen> * penList;
+    QList<QPen> *penList;
     bool penChange;
-
-
 };
 
+enum Operation_t
+{
+    Stop,
+    Probe,
+    Ping,
+    ReadADC,
+    Start
+};
 
 #endif // TYPEDEFS_H


### PR DESCRIPTION
The original code uses a timer which runs every 500ms and this timer manages the state machine which uses the serial protocol to control the uTracer 3.

Debug was added to the protocol state machine which revealed that the timer continues to fire after the state machine reaches the full idle state. This is inefficient so add functions to control the creation and destruction of the timer object. This means the timer object only exists when the protocol state machine is running.

In addition, focus the various operation requests through a single function so that the GUI requests can be isolated from the protocol state machine.

Some of the files were cleaned up to make it easier to make consistent changes.