### PR TITLE
Implement new serial protocol state machine

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -490,7 +490,6 @@ void MainWindow::RxData()
 {
     static int time;
     static int delay;
-    static int rxLen;
     static int HV_Discharge_Timer;
     char buf[30];
     //I Limits         200,  175,  150,  125, 100,    50,   25,   12,  7mA,  Off
@@ -504,7 +503,6 @@ void MainWindow::RxData()
     {
         qDebug() << "RxData: Action sendADC";
         TxString = "500000000000000000";
-        rxLen = TxString.length() + 38;
         heat = 0;
         sendSer(38);
         sendADC = false;
@@ -518,7 +516,6 @@ void MainWindow::RxData()
     {
         qDebug() << "RxData: Action sendPing";
         TxString = "300000000000000000";
-        rxLen = TxString.length();
         heat = 0;
         sendSer(0);
         sendPing = false;
@@ -546,7 +543,6 @@ void MainWindow::RxData()
         ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
         TxString = "300000000000000000";
         response.clear();
-        rxLen = TxString.length();
         sendSer(0);
         timer_on = false;
         status = Idle;
@@ -559,7 +555,6 @@ void MainWindow::RxData()
         qDebug() << "RxData: Action RxCode RXINVALID";
         ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
         response.clear();
-        rxLen = 0;
         timer_on = false;
         status = Idle;
         return;
@@ -574,7 +569,6 @@ void MainWindow::RxData()
     {
         case Idle:
         {
-            rxLen = 0;
             timer_on = false;
             time = 0;
 
@@ -611,7 +605,6 @@ void MainWindow::RxData()
                 TxString += buf;
                 ::snprintf(buf, 3, "%02X", Ir[options.IaRange]);
                 TxString += buf;
-                rxLen = 18;
                 sendSer(0);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -627,7 +620,6 @@ void MainWindow::RxData()
         {
             if (RxCode == RXSUCCESS)
             {
-                rxLen = 0;
                 status = Idle;
                 ui->statusBar->showMessage("Ping OK");
                 timer_on = false;
@@ -640,7 +632,6 @@ void MainWindow::RxData()
             if (RxCode == RXSUCCESS)
             {
                 saveADCInfo(&response);
-                rxLen = 0;
                 status = Idle;
                 ui->statusBar->showMessage("Ready");
                 timer_on = false;
@@ -655,7 +646,6 @@ void MainWindow::RxData()
                 ui->statusBar->showMessage("Heating, get ADC info");
                 status = Heating_wait_adc;
                 TxString = "500000000000000000";
-                rxLen = TxString.length() + 38;
                 sendSer(38);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -672,7 +662,6 @@ void MainWindow::RxData()
                 status = Heating;
                 ui->statusBar->showMessage("Heating");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -690,7 +679,6 @@ void MainWindow::RxData()
                 ui->HeaterProg->setValue(0);
                 ui->statusBar->showMessage("Heater off");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
                 timeout = PING_TIMEOUT;
@@ -710,7 +698,6 @@ void MainWindow::RxData()
                     if (VfADC > 1023) VfADC = 1023;
                     ::snprintf(buf, 19, "40000000000000%04X", VfADC);
                     TxString = buf;
-                    rxLen = TxString.length();
                     timeout = PING_TIMEOUT;
                     sendSer(0);
                     heat++;
@@ -720,7 +707,6 @@ void MainWindow::RxData()
                     ui->HeaterProg->setValue(100);
                     status = heat_done;
                     timer_on = false;
-                    rxLen = 0;
                 }
             }
             break;
@@ -737,7 +723,6 @@ void MainWindow::RxData()
                 status = HeatOff;
                 HV_Discharge_Timer = 0;
                 TxString = "400000000000000000";
-                rxLen=TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
                 timeout = PING_TIMEOUT;
@@ -747,7 +732,6 @@ void MainWindow::RxData()
             {
                 startSweep = 0;
                 if (dataStore->length() > 0) dataStore->clear();
-                rxLen = 0;
                 CreateTestVectors();
                 curve = 0;
                 status = Sweep_set;
@@ -765,7 +749,6 @@ void MainWindow::RxData()
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
                 timeout = PING_TIMEOUT;
@@ -787,7 +770,6 @@ void MainWindow::RxData()
                 timer_on = true;
                 ::snprintf(buf, 19, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC );
                 TxString= buf;
-                rxLen= TxString.length() + 38;
                 sendSer(38);
             }
             else
@@ -806,7 +788,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    rxLen = TxString.length();
                     sendSer(0);
                     heat=0;
                     timeout = PING_TIMEOUT;
@@ -822,7 +803,6 @@ void MainWindow::RxData()
                 timer_on = true;
                 sprintf(buf, "20%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
                 TxString = buf;
-                rxLen = TxString.length();
                 sendSer(0);
             }
             break;
@@ -831,7 +811,6 @@ void MainWindow::RxData()
         {
             status = hold;
             timer_on = false;
-            rxLen = 0;
             break;
         }
         case hold:
@@ -845,7 +824,6 @@ void MainWindow::RxData()
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
                 timeout = PING_TIMEOUT;
@@ -868,7 +846,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    rxLen = TxString.length();
                     sendSer(0);
                     heat = 0;
                     timeout = PING_TIMEOUT;
@@ -884,7 +861,6 @@ void MainWindow::RxData()
                 timer_on = true;
                 sprintf(buf, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
                 TxString = buf;
-                rxLen = TxString.length() + 38;
                 sendSer(38);
             }
             else
@@ -892,7 +868,6 @@ void MainWindow::RxData()
                 ui->statusBar->showMessage("Sweep (Holding)");
                 delay--;
                 status = hold;
-                rxLen = 0;
             }
             break;
         }
@@ -916,7 +891,6 @@ void MainWindow::RxData()
                         HV_Discharge_Timer =distime;
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        rxLen = TxString.length();
                         sendSer(0);
                         break;
                     }
@@ -956,7 +930,6 @@ void MainWindow::RxData()
                     delay = options.Delay;
                     status = Sweep_set;
                     timeout = ADC_READ_TIMEOUT;
-                    rxLen = 0;
                 }
                 else
                 {
@@ -975,7 +948,6 @@ void MainWindow::RxData()
                         ui->statusBar->showMessage("Sweep complete");
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        rxLen = TxString.length();
                         sendSer(0);
                     }
                 }
@@ -988,7 +960,6 @@ void MainWindow::RxData()
             if (HV_Discharge_Timer == (distime-1))
             {
                 TxString = "300000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
                 ui->HeaterProg->setValue(0);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -498,14 +498,13 @@ void MainWindow::RxData()
     static int lim[]={0x8f, 0x8d, 0xad, 0xab, 0x84, 0xa4, 0xa2, 0xa1, 0x80, 0x00};
     static int avg[]={0x40, 1, 2, 4, 8, 16, 32, 0x40};
     static int Ir[]={8,1,2,3,4,5,6,7};
-    static QByteArray cmd;
     static QByteArray response;
     static int distime;
 
     if (sendADC == true)
     {
         qDebug() << "RxData: Action sendADC";
-        cmd = TxString = "500000000000000000";
+        TxString = "500000000000000000";
         rxLen = TxString.length() + 38;
         heat = 0;
         sendSer(38);
@@ -519,7 +518,7 @@ void MainWindow::RxData()
     if (sendPing == true)
     {
         qDebug() << "RxData: Action sendPing";
-        cmd = TxString = "300000000000000000";
+        TxString = "300000000000000000";
         rxLen = TxString.length();
         heat = 0;
         sendSer(0);
@@ -548,7 +547,6 @@ void MainWindow::RxData()
         ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
         TxString = "300000000000000000";
         response.clear();
-        cmd = TxString;
         rxLen = TxString.length();
         sendSer(0);
         timer_on = false;
@@ -614,7 +612,6 @@ void MainWindow::RxData()
                 TxString += buf;
                 ::snprintf(buf, 3, "%02X", Ir[options.IaRange]);
                 TxString += buf;
-                cmd = TxString;
                 rxLen = 18;
                 sendSer(0);
                 timer_on = true;
@@ -632,7 +629,6 @@ void MainWindow::RxData()
             if (RxCode == RXSUCCESS)
             {
                 rxLen = 0;
-                cmd = "";
                 status = Idle;
                 ui->statusBar->showMessage("Ping OK");
                 timer_on = false;
@@ -646,7 +642,6 @@ void MainWindow::RxData()
             {
                 saveADCInfo(&response);
                 rxLen = 0;
-                cmd = "";
                 status = Idle;
                 ui->statusBar->showMessage("Ready");
                 timer_on = false;
@@ -660,7 +655,7 @@ void MainWindow::RxData()
             {
                 ui->statusBar->showMessage("Heating, get ADC info");
                 status = Heating_wait_adc;
-                cmd = TxString = "500000000000000000";
+                TxString = "500000000000000000";
                 rxLen = TxString.length() + 38;
                 sendSer(38);
                 timer_on = true;
@@ -679,7 +674,6 @@ void MainWindow::RxData()
                 ui->statusBar->showMessage("Heating");
                 TxString = "400000000000000000";
                 rxLen = TxString.length();
-                cmd = TxString;
                 sendSer(0);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -697,7 +691,6 @@ void MainWindow::RxData()
                 ui->HeaterProg->setValue(0);
                 ui->statusBar->showMessage("Heater off");
                 TxString = "400000000000000000";
-                cmd = TxString;
                 rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
@@ -719,7 +712,6 @@ void MainWindow::RxData()
                     ::snprintf(buf, 19, "40000000000000%04X", VfADC);
                     TxString = buf;
                     rxLen = TxString.length();
-                    cmd = TxString;
                     timeout = PING_TIMEOUT;
                     sendSer(0);
                     heat++;
@@ -730,7 +722,6 @@ void MainWindow::RxData()
                     status = heat_done;
                     timer_on = false;
                     rxLen = 0;
-                    cmd = "";
                 }
             }
             break;
@@ -746,7 +737,7 @@ void MainWindow::RxData()
                 stop = false;
                 status = HeatOff;
                 HV_Discharge_Timer = 0;
-                cmd=TxString = "400000000000000000";
+                TxString = "400000000000000000";
                 rxLen=TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
@@ -758,7 +749,6 @@ void MainWindow::RxData()
                 startSweep = 0;
                 if (dataStore->length() > 0) dataStore->clear();
                 rxLen = 0;
-                cmd = "";
                 CreateTestVectors();
                 curve = 0;
                 status = Sweep_set;
@@ -775,7 +765,7 @@ void MainWindow::RxData()
                 distime = (int)(DISTIME * v / 400);
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
-                cmd = TxString = "400000000000000000";
+                TxString = "400000000000000000";
                 rxLen = TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
@@ -797,7 +787,7 @@ void MainWindow::RxData()
                 timeout = ADC_READ_TIMEOUT;
                 timer_on = true;
                 ::snprintf(buf, 19, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC );
-                cmd = TxString= buf;
+                TxString= buf;
                 rxLen= TxString.length() + 38;
                 sendSer(38);
             }
@@ -817,7 +807,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    cmd = TxString;
                     rxLen = TxString.length();
                     sendSer(0);
                     heat=0;
@@ -833,7 +822,7 @@ void MainWindow::RxData()
                 timeout = ADC_READ_TIMEOUT + options.Delay;
                 timer_on = true;
                 sprintf(buf, "20%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
-                cmd = TxString = buf;
+                TxString = buf;
                 rxLen = TxString.length();
                 sendSer(0);
             }
@@ -844,7 +833,6 @@ void MainWindow::RxData()
             status = hold;
             timer_on = false;
             rxLen = 0;
-            cmd = "";
             break;
         }
         case hold:
@@ -858,7 +846,6 @@ void MainWindow::RxData()
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
                 TxString = "400000000000000000";
-                cmd = TxString;
                 rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
@@ -882,7 +869,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    cmd = TxString;
                     rxLen = TxString.length();
                     sendSer(0);
                     heat = 0;
@@ -898,7 +884,7 @@ void MainWindow::RxData()
                 timeout = ADC_READ_TIMEOUT;
                 timer_on = true;
                 sprintf(buf, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
-                cmd = TxString = buf;
+                TxString = buf;
                 rxLen = TxString.length() + 38;
                 sendSer(38);
             }
@@ -908,7 +894,6 @@ void MainWindow::RxData()
                 delay--;
                 status = hold;
                 rxLen = 0;
-                cmd = "";
             }
             break;
         }
@@ -932,7 +917,6 @@ void MainWindow::RxData()
                         HV_Discharge_Timer =distime;
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        cmd = TxString;
                         rxLen = TxString.length();
                         sendSer(0);
                         break;
@@ -974,7 +958,6 @@ void MainWindow::RxData()
                     status = Sweep_set;
                     timeout = ADC_READ_TIMEOUT;
                     rxLen = 0;
-                    cmd = "";
                 }
                 else
                 {
@@ -993,7 +976,6 @@ void MainWindow::RxData()
                         ui->statusBar->showMessage("Sweep complete");
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        cmd = TxString;
                         rxLen = TxString.length();
                         sendSer(0);
                     }
@@ -1006,7 +988,7 @@ void MainWindow::RxData()
             if (HV_Discharge_Timer>0) HV_Discharge_Timer--;
             if (HV_Discharge_Timer == (distime-1))
             {
-                cmd = TxString = "300000000000000000";
+                TxString = "300000000000000000";
                 rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -430,7 +430,6 @@ void MainWindow::readData()
         while (portInUse->bytesAvailable())
         {
             rxChar = portInUse->read(1).at(0);
-            RxString.append(rxChar);
             SendCommand(NULL, false, rxChar);
         }
     }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -204,7 +204,6 @@ private:
     QTimer *timer;
     bool ok;
     bool newMessage;
-    QByteArray RxString;
     float Vdi;
     float power;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -285,7 +285,7 @@ private:
     int GetVs(float);
     int GetVg(float);
     int GetVf(float);
-    void sendSer();
+    void sendSer(int ExpectedRspLen);
     void StoreData(bool);
     void SetUpPlot();
     bool SetUpSweepParams();
@@ -297,5 +297,6 @@ private:
     void StartUpMachine();
     void StopTheMachine();
     int RxPkt(int len, QByteArray *pCmd, QByteArray *pResponse);
+    void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
 };
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -296,7 +296,7 @@ private:
     bool SaveTubeDataFile();
     void StartUpMachine();
     void StopTheMachine();
-    int RxPkt(int len, QByteArray *pCmd, QByteArray *pResponse);
+    int RxPkt(QByteArray *pResponse);
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
 };
 #endif // MAINWINDOW_H

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -60,4 +60,36 @@ enum Operation_t
     Start
 };
 
+// Temporarily global
+enum RxState_t
+{
+    RxIdle,
+    RxEchoed,
+    RxEchoError,
+    RxResponse,
+    RxComplete
+};
+
+// Temporarily global
+enum TxState_t
+{
+    TxIdle,
+    TxLoaded,
+    TxSending,
+    TxRxing,
+    TxComplete
+};
+
+// Temporarily global
+struct CommandResponse_t
+{
+    QByteArray Command;
+    int txPos;
+    TxState_t txState;
+    int ExpectedRspLen;
+    QByteArray Response;
+    int rxPos;
+    RxState_t rxState;
+};
+
 #endif // TYPEDEFS_H


### PR DESCRIPTION
Add SendCommand() to implement a state machine to handle the Data Protocol of the uTracer.

```
The state machine manages the following:

1. Manages TX and RX states transitions.

2. Transmits single characters of the command message and checks that
   the character is echoed. Therefore, a communications failure can
   be detected such as the uTracer not being present.

3. Handles switches between sending a command message and, if expected,
   receiving a message. This is half-duplex; a command and response
   cannot occur at the same time.

4. Uses a structure to hold the messages and states. This allows for
   potential flexibility such as dynamic allocation of the structures.

This solution is an improvement on the original design because this
design is more concise. Also, the design follows the design of the protocol
more closely such as enforcing half-duplex transmission / reception.
```
Note that CommandResponse_t CmdRsp is temporarily global due to not being fully integrated into the existing codebase. Additional code refactoring will eventually eliminate the global structure.

Modify RxPkt() to use the output from the new state machine. However, retain the original protocol timeout mechanism.

Remove the following variables which are now redundant:
cmd
RxString
rxlen