### PR TITLE
Integrate uTracer protocol message command and response functions 

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -141,6 +141,11 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->Tabs->setCurrentIndex(0);
     //
     optimizer = new dr_optimize();
+
+    // Initalise the command response structure
+    CmdRsp.txState = TxIdle;
+    CmdRsp.rxState = RxIdle;
+    CmdRsp.timeout = 0;
 }
 
 MainWindow::~MainWindow()
@@ -317,9 +322,6 @@ void MainWindow::StopTheMachine()
     }
 }
 
-// Temporarily file global
-CommandResponse_t CmdRsp;
-
 void MainWindow::SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar)
 {
     static CommandResponse_t *pSendCmdRsp = NULL;
@@ -433,11 +435,9 @@ void MainWindow::readData()
     }
 }
 
-int MainWindow::RxPkt(QByteArray *response)
+int MainWindow::RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response)
 {
     int rxStatus = RXCONTINUE;
-    // Temporary
-    CommandResponse_t *pSendCmdRsp = &CmdRsp;
 
     if (pSendCmdRsp->timeout)
     {
@@ -609,7 +609,7 @@ void MainWindow::RxData()
 
     // ---------------------------------------------------
     // Check for the uTracer response
-    int RxCode = RxPkt(&response);
+    int RxCode = RxPkt(&CmdRsp, &response);
     // Check for timeout
     if (RxCode == RXTIMEOUT)
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -94,7 +94,6 @@ MainWindow::MainWindow(QWidget *parent) :
     status=Idle;
     startSweep=0;
     stop=false;
-    timeout=PING_TIMEOUT;
     timer=NULL;
     newMessage=false;
     sendADC=false;
@@ -440,11 +439,11 @@ int MainWindow::RxPkt(QByteArray *response)
     // Temporary
     CommandResponse_t *pSendCmdRsp = &CmdRsp;
 
-    if (timeout)
+    if (pSendCmdRsp->timeout)
     {
-        timeout--;
+        pSendCmdRsp->timeout--;
 
-        if (timeout == 0)
+        if (pSendCmdRsp->timeout == 0)
         {
             qDebug() << "RxPkt: TIMEOUT - try reading for missing RX";
             readData();
@@ -464,7 +463,7 @@ int MainWindow::RxPkt(QByteArray *response)
         pSendCmdRsp->txState = TxIdle;
         pSendCmdRsp->rxState = RxIdle;
 
-        timeout = 0;
+        pSendCmdRsp->timeout = 0;
 
         // For the debug window
         TxString = pSendCmdRsp->Command;
@@ -497,7 +496,7 @@ void MainWindow::SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uin
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -513,7 +512,7 @@ void MainWindow::SendGetMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint1
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 38;
-    timeout = ADC_READ_TIMEOUT;
+    pSendCmdRsp->timeout = ADC_READ_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -529,7 +528,7 @@ void MainWindow::SendHoldMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = ADC_READ_TIMEOUT + delay;
+    pSendCmdRsp->timeout = ADC_READ_TIMEOUT + delay;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -538,7 +537,7 @@ void MainWindow::SendEndMeasurementCommand(CommandResponse_t *pSendCmdRsp)
     qDebug() << "Send End Measurement command:";
     pSendCmdRsp->Command = "300000000000000000";
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -552,7 +551,7 @@ void MainWindow::SendFilamentCommand(CommandResponse_t *pSendCmdRsp, uint16_t fi
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -561,7 +560,7 @@ void MainWindow::SendADCCommand(CommandResponse_t *pSendCmdRsp)
     qDebug() << "Send ADC command:";
     pSendCmdRsp->Command = "500000000000000000";
     pSendCmdRsp->ExpectedRspLen = 38;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -945,7 +944,6 @@ void MainWindow::RxData()
                     ui->statusBar->showMessage(msg);
                     delay = options.Delay;
                     status = Sweep_set;
-                    timeout = ADC_READ_TIMEOUT;
                 }
                 else
                 {
@@ -992,7 +990,6 @@ void MainWindow::RxData()
             }
             else
             {
-                timeout = PING_TIMEOUT;
                 QString msg = QString("Countdown for HV to discharge: %1").arg(HV_Discharge_Timer);
                 ui->statusBar->showMessage(msg);
             }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -270,6 +270,38 @@ private:
 
     QSerialPort *portInUse;
 
+    enum RxState_t
+    {
+        RxIdle,
+        RxEchoed,
+        RxEchoError,
+        RxResponse,
+        RxComplete
+    };
+
+    enum TxState_t
+    {
+        TxIdle,
+        TxLoaded,
+        TxSending,
+        TxRxing,
+        TxComplete
+    };
+
+    struct CommandResponse_t
+    {
+        QByteArray Command;
+        int txPos;
+        TxState_t txState;
+        int ExpectedRspLen;
+        QByteArray Response;
+        int rxPos;
+        RxState_t rxState;
+        int timeout;
+    };
+
+    CommandResponse_t CmdRsp;
+
     // Function protoypes
     void PenUpdate();
     void updateLcdsWithModel();
@@ -292,7 +324,7 @@ private:
     bool SaveTubeDataFile();
     void StartUpMachine();
     void StopTheMachine();
-    int RxPkt(QByteArray *pResponse);
+    int RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response);
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
     void SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint8_t limits, uint8_t averaging,
                                      uint8_t screenGain, uint8_t anodeGain);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -199,7 +199,6 @@ private:
     int curve;
     int heat;
     bool stop;
-    int timeout;
     QTimer *timer;
     bool ok;
     bool newMessage;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -283,7 +283,6 @@ private:
     int GetVs(float);
     int GetVg(float);
     int GetVf(float);
-    void sendSer(int ExpectedRspLen);
     void StoreData(bool);
     void SetUpPlot();
     bool SetUpSweepParams();
@@ -296,5 +295,14 @@ private:
     void StopTheMachine();
     int RxPkt(QByteArray *pResponse);
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
+    void SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint8_t limits, uint8_t averaging,
+                                     uint8_t screenGain, uint8_t anodeGain);
+    void SendGetMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint16_t anodeV, uint16_t screenV,
+                                   uint16_t gridV, uint16_t filamentV);
+    void SendHoldMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint16_t anodeV, uint16_t screenV,
+                                    uint16_t gridV, uint16_t filamentV, int delay);
+    void SendEndMeasurementCommand(CommandResponse_t *pSendCmdRsp);
+    void SendFilamentCommand(CommandResponse_t *pSendCmdRsp, uint16_t filament);
+    void SendADCCommand(CommandResponse_t *pSendCmdRsp);
 };
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -199,7 +199,6 @@ private:
     int curve;
     int heat;
     bool stop;
-    bool timer_on;
     int timeout;
     QTimer *timer;
     bool ok;

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -60,37 +60,4 @@ enum Operation_t
     Start
 };
 
-// Temporarily global
-enum RxState_t
-{
-    RxIdle,
-    RxEchoed,
-    RxEchoError,
-    RxResponse,
-    RxComplete
-};
-
-// Temporarily global
-enum TxState_t
-{
-    TxIdle,
-    TxLoaded,
-    TxSending,
-    TxRxing,
-    TxComplete
-};
-
-// Temporarily global
-struct CommandResponse_t
-{
-    QByteArray Command;
-    int txPos;
-    TxState_t txState;
-    int ExpectedRspLen;
-    QByteArray Response;
-    int rxPos;
-    RxState_t rxState;
-    int timeout;
-};
-
 #endif // TYPEDEFS_H

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -90,6 +90,7 @@ struct CommandResponse_t
     QByteArray Response;
     int rxPos;
     RxState_t rxState;
+    int timeout;
 };
 
 #endif // TYPEDEFS_H


### PR DESCRIPTION
Abstract the uTracer protocol messages into specific functions which create the command messages and read the resulting response (if any).

This simplifies the main state machine by moving that code into specific functions. Any subsequent redundant variables or functions have been removed.