### PR TITLE
Incorporate the user requests into the main state machine

### DIFF
--- a/src/debug_dialog.cpp
+++ b/src/debug_dialog.cpp
@@ -123,26 +123,46 @@ void debug_dialog::UpdateVals()
 
 void debug_dialog::UpdateComSel()
 {
-    //Scrub current List
-    openPortEn =false;
+    // Scrub current List
+    openPortEn = false;
     ui->ComSel->clear();
 
-    int i=0;
-    foreach (QSerialPortInfo port, mw->serPortInfo) {
+    int portEntries = 0;
+    int portNonEntries = 0;
+    int firstEntry = -1;
+    int firstNonEntry = -1;
+    bool currentSerialPort = false;
+    foreach (QSerialPortInfo port, mw->serPortInfo)
+    {
         if (!port.portName().isNull())
         {
             ui->ComSel->addItem(port.portName());
-            qDebug() << "setting serPortInfo, comport:" << port.portName() << mw->comport;
+            qDebug() << "UpdateComSel(): serPortInfo:" << port.portName() << " comport:" << mw->comport;
             if (port.portName().contains(mw->comport))
             {
-                ui->ComSel->setCurrentIndex(i);
+                ui->ComSel->setCurrentIndex(portNonEntries);
+                currentSerialPort = true;
             }
-            i++;
+            if (firstEntry == -1)
+            {
+                firstEntry = portEntries;
+                firstNonEntry = portNonEntries;
+            }
+            portNonEntries++;
         }
+        portEntries++;
     }
-    openPortEn=true;
-    QString comport = mw->serPortInfo.at(0).portName();
-    if (i == 1) mw->OpenComPort(&comport, true);
+
+    // If the requested serial port is not found then select the first entry in the list (if available),
+    // then open it, and update the calibration file with the new serial port name.
+    if (!currentSerialPort && firstEntry != -1)
+    {
+        QString comport = mw->serPortInfo.at(firstEntry).portName();
+        qDebug() << "UpdateComSel(): Selecting the default serial port:" << comport;
+        ui->ComSel->setCurrentIndex(firstNonEntry);
+        mw->OpenComPort(&comport, true);
+    }
+    openPortEn = true;
 }
 
 

--- a/src/debug_dialog.cpp
+++ b/src/debug_dialog.cpp
@@ -164,6 +164,10 @@ void debug_dialog::UpdateComSel()
         ui->ComSel->setCurrentIndex(firstNonEntry);
         mw->OpenComPort(&comport, true);
     }
+
+    // If the list of serial ports is empty then ensure the serial port is closed
+    if (!portNonEntries) mw->CloseComPort();
+
     openPortEn = true;
 }
 

--- a/src/debug_dialog.cpp
+++ b/src/debug_dialog.cpp
@@ -184,11 +184,12 @@ void debug_dialog::on_OK_clicked()
 
 void debug_dialog::on_Ping_clicked()
 {
-    mw->sendADC=true;
+    // Button is actually "Read ADC"
+    mw->RequestOperation((Operation_t) ReadADC);
 }
 
 
 void debug_dialog::on_pushPing_clicked()
 {
-    mw->sendPing=true;
+    mw->RequestOperation((Operation_t) Ping);
 }

--- a/src/debug_dialog.cpp
+++ b/src/debug_dialog.cpp
@@ -127,14 +127,16 @@ void debug_dialog::UpdateComSel()
     openPortEn = false;
     ui->ComSel->clear();
 
+    // Get a list of serial ports
+    QList<QSerialPortInfo> serPortInfo = QSerialPortInfo::availablePorts();
     int portEntries = 0;
     int portNonEntries = 0;
     int firstEntry = -1;
     int firstNonEntry = -1;
     bool currentSerialPort = false;
-    foreach (QSerialPortInfo port, mw->serPortInfo)
+    foreach (QSerialPortInfo port, serPortInfo)
     {
-        if (!port.portName().isNull())
+        if (!port.portName().isEmpty())
         {
             ui->ComSel->addItem(port.portName());
             qDebug() << "UpdateComSel(): serPortInfo:" << port.portName() << " comport:" << mw->comport;
@@ -157,7 +159,7 @@ void debug_dialog::UpdateComSel()
     // then open it, and update the calibration file with the new serial port name.
     if (!currentSerialPort && firstEntry != -1)
     {
-        QString comport = mw->serPortInfo.at(firstEntry).portName();
+        QString comport = serPortInfo.at(firstEntry).portName();
         qDebug() << "UpdateComSel(): Selecting the default serial port:" << comport;
         ui->ComSel->setCurrentIndex(firstNonEntry);
         mw->OpenComPort(&comport, true);

--- a/src/debug_dialog.cpp
+++ b/src/debug_dialog.cpp
@@ -142,13 +142,13 @@ void debug_dialog::UpdateComSel()
     }
     openPortEn=true;
     QString comport = mw->serPortInfo.at(0).portName();
-    if (i==1) mw->OpenComPort(&comport);
+    if (i == 1) mw->OpenComPort(&comport, true);
 }
 
 
 void debug_dialog::on_ComSel_currentIndexChanged(const QString &arg1)
 {
-   if (openPortEn) mw->OpenComPort(&arg1);
+    if (openPortEn) mw->OpenComPort(&arg1, true);
 }
 
 void debug_dialog::on_OK_clicked()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,31 @@ int main(int argc, char *argv[])
     QApplication a(argc, argv);
 
     MainWindow w;
+
+    w.uTmaxDir = QDir::homePath();
+    w.uTmaxDir.append("/uTmax_files/");
+    qDebug() << "Home directory:" << w.uTmaxDir;
+    QDir dir(w.uTmaxDir);
+    if(!dir.exists())
+    {
+        qDebug() << "ERROR: Home directory does not exist:" << w.uTmaxDir;
+        std::exit(EXIT_FAILURE);
+    }
+
+    // Read the default tube data file or ask for the file
+    w.dataFileName = w.uTmaxDir;
+    w.dataFileName.append("data.csv");
+    if (!w.ReadDataFile())
+        std::exit(EXIT_FAILURE);
+
+    // Read the calibration file or create a fresh file
+    w.calFileName = w.uTmaxDir;
+    w.calFileName.append("cal.txt");
+    if (!w.ReadCalibration())
+        std::exit(EXIT_FAILURE);
+
+    w.SerialPortDiscovery();
+
     w.show();
     
     return a.exec();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -148,9 +148,17 @@ MainWindow::MainWindow(QWidget *parent) :
 MainWindow::~MainWindow()
 {
     delete optimizer;
+    if (timer) {
+        qDebug() << "~MainWindow: Disconnecting timer";
+        disconnect(timer, SIGNAL(timeout()), this, SLOT(RxData()));
+        delete timer;
+    }
     //Close open port
-    if (portInUse->isOpen()  ) {
+    if (portInUse && portInUse->isOpen()) {
+        qDebug() << "~MainWindow: Disconnecting serial port";
+        disconnect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         portInUse->close();
+        delete portInUse;
     }
     delete ui;
 }
@@ -166,7 +174,6 @@ void MainWindow::SerialPortDiscovery()
     portInUse->setStopBits(QSerialPort::OneStop);
     portInUse->setFlowControl(QSerialPort::NoFlowControl);
     //10 bits????
-    connect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
 
     //get a list of ports
     serPortInfo = QSerialPortInfo::availablePorts();
@@ -192,6 +199,7 @@ void MainWindow::OpenComPort(const QString *portName)
     qDebug() <<"MainWindow::OpenComPort";
     //Close open port
     if (portInUse->isOpen()) {
+        disconnect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         qDebug() << "Closing Port:" << portInUse->portName();
         portInUse->close();
     }
@@ -202,6 +210,7 @@ void MainWindow::OpenComPort(const QString *portName)
     QString msg;
     if ( portInUse->open(QIODevice::ReadWrite))
     {
+        connect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         msg = QString("Port %1 opened").arg(comport);
         SaveCalFile(); //Update cal file with new port info
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -277,37 +277,34 @@ void MainWindow::readData()
     if (portInUse) RxString.append(portInUse->readAll());
 }
 
-int MainWindow::RxPkt(int len, QByteArray * cmd, QByteArray * response)
+int MainWindow::RxPkt(int len, QByteArray *cmd, QByteArray *response)
 {
-    //if (portInUse->bytesAvailable()>0)   RxString.append(portInUse->readAll());
     if (len==0) return RXCONTINUE;
-    //qDebug() << "RxPkt: cmd is: len=" << len << "cmd=" << cmd->constData();
     timeout--;
-    if (timeout ==0) {
+    if (timeout == 0)
+    {
         RxString.clear();
         response->clear();
         qDebug() << "RxPkt: TIMEOUT";
         return RXTIMEOUT;
     }
-    //if (RxString.length()>0) qDebug() << "RxPkt: RxString is:" << RxString << "len is now::" << RxString.length();
-    if (RxString.length()>=len) {
-        if ( (cmd->length()==0) || RxString.startsWith(* cmd) ) {
-            * response = RxString.mid(cmd->length(),len);
-            //qDebug() << "RxPkt: reply OK, response" << response->constData();
+    if (RxString.length() >= len)
+    {
+        if ((cmd->length() == 0) || RxString.startsWith(*cmd))
+        {
+            *response = RxString.mid(cmd->length(), len);
             RxString.clear();
-            if (len==18) echoString = TxString;
-            if (len==38+18) {
+            if (len == 18) echoString = TxString;
+            if (len == 38 + 18)
+            {
                 echoString = TxString;
                 statusString = response->constData();
             }
-            //if (len==18+18) {
-            //    echoString = TxString;
-            //    statusString = response->constData();
-            //}
             cmd->clear();
-            return RXSUCCESS ;
+            return RXSUCCESS;
         }
-        else {
+        else
+        {
             qDebug() << "RxPkt: reply invalid=" << RxString;
             RxString.clear();
             response->clear();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -148,6 +148,14 @@ MainWindow::MainWindow(QWidget *parent) :
     //appDir = QCoreApplication.applicationDirPath()
     uTmaxDir = QDir::homePath();
     uTmaxDir.append("/uTmax_files/");
+    qDebug() << "Home directory:" << uTmaxDir;
+    QDir dir(uTmaxDir);
+    if(!dir.exists())
+    {
+        qDebug() << "ERROR: Home directory does not exist:" << uTmaxDir;
+        std::exit(EXIT_FAILURE);
+    }
+
     dataFileName = uTmaxDir;
     dataFileName.append("data.csv");
     ReadDataFile();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -490,7 +490,6 @@ void MainWindow::RxData()
 {
     static int time;
     static int delay;
-    static int rxLen;
     static int HV_Discharge_Timer;
     char buf[30];
     //I Limits         200,  175,  150,  125, 100,    50,   25,   12,  7mA,  Off
@@ -504,7 +503,6 @@ void MainWindow::RxData()
     {
         qDebug() << "RxData: Action sendADC";
         TxString = "500000000000000000";
-        rxLen = TxString.length() + 38;
         heat = 0;
         sendSer(38);
         sendADC = false;
@@ -518,7 +516,6 @@ void MainWindow::RxData()
     {
         qDebug() << "RxData: Action sendPing";
         TxString = "300000000000000000";
-        rxLen = TxString.length();
         heat = 0;
         sendSer(0);
         sendPing = false;
@@ -546,7 +543,6 @@ void MainWindow::RxData()
         ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
         TxString = "300000000000000000";
         response.clear();
-        rxLen = TxString.length();
         sendSer(0);
         timer_on = false;
         status = Idle;
@@ -559,7 +555,6 @@ void MainWindow::RxData()
         qDebug() << "RxData: Action RxCode RXINVALID";
         ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
         response.clear();
-        rxLen = 0;
         timer_on = false;
         status = Idle;
         return;
@@ -574,7 +569,6 @@ void MainWindow::RxData()
     {
         case Idle:
         {
-            rxLen = 0;
             timer_on = false;
             time = 0;
 
@@ -611,7 +605,6 @@ void MainWindow::RxData()
                 TxString += buf;
                 ::snprintf(buf, 3, "%02X", Ir[options.IaRange]);
                 TxString += buf;
-                rxLen = 18;
                 sendSer(0);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -627,7 +620,6 @@ void MainWindow::RxData()
         {
             if (RxCode == RXSUCCESS)
             {
-                rxLen = 0;
                 status = Idle;
                 ui->statusBar->showMessage("Ping OK");
                 timer_on = false;
@@ -640,7 +632,6 @@ void MainWindow::RxData()
             if (RxCode == RXSUCCESS)
             {
                 saveADCInfo(&response);
-                rxLen = 0;
                 status = Idle;
                 ui->statusBar->showMessage("Ready");
                 timer_on = false;
@@ -655,7 +646,6 @@ void MainWindow::RxData()
                 ui->statusBar->showMessage("Heating, get ADC info");
                 status = Heating_wait_adc;
                 TxString = "500000000000000000";
-                rxLen = TxString.length() + 38;
                 sendSer(38);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -672,7 +662,6 @@ void MainWindow::RxData()
                 status = Heating;
                 ui->statusBar->showMessage("Heating");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -690,7 +679,6 @@ void MainWindow::RxData()
                 ui->HeaterProg->setValue(0);
                 ui->statusBar->showMessage("Heater off");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
                 timeout = PING_TIMEOUT;
@@ -710,7 +698,6 @@ void MainWindow::RxData()
                     if (VfADC > 1023) VfADC = 1023;
                     ::snprintf(buf, 19, "40000000000000%04X", VfADC);
                     TxString = buf;
-                    rxLen = TxString.length();
                     timeout = PING_TIMEOUT;
                     sendSer(0);
                     heat++;
@@ -720,7 +707,6 @@ void MainWindow::RxData()
                     ui->HeaterProg->setValue(100);
                     status = heat_done;
                     timer_on = false;
-                    rxLen = 0;
                 }
             }
             break;
@@ -737,7 +723,6 @@ void MainWindow::RxData()
                 status = HeatOff;
                 HV_Discharge_Timer = 0;
                 TxString = "400000000000000000";
-                rxLen=TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
                 timeout = PING_TIMEOUT;
@@ -747,7 +732,6 @@ void MainWindow::RxData()
             {
                 startSweep = 0;
                 if (dataStore->length() > 0) dataStore->clear();
-                rxLen = 0;
                 CreateTestVectors();
                 curve = 0;
                 status = Sweep_set;
@@ -765,7 +749,6 @@ void MainWindow::RxData()
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
                 timeout = PING_TIMEOUT;
@@ -787,7 +770,6 @@ void MainWindow::RxData()
                 timer_on = true;
                 ::snprintf(buf, 19, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC );
                 TxString= buf;
-                rxLen= TxString.length() + 38;
                 sendSer(38);
             }
             else
@@ -806,7 +788,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    rxLen = TxString.length();
                     sendSer(0);
                     heat=0;
                     timeout = PING_TIMEOUT;
@@ -822,7 +803,6 @@ void MainWindow::RxData()
                 timer_on = true;
                 sprintf(buf, "20%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
                 TxString = buf;
-                rxLen = TxString.length();
                 sendSer(0);
             }
             break;
@@ -831,7 +811,6 @@ void MainWindow::RxData()
         {
             status = hold;
             timer_on = false;
-            rxLen = 0;
             break;
         }
         case hold:
@@ -845,7 +824,6 @@ void MainWindow::RxData()
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
                 timeout = PING_TIMEOUT;
@@ -868,7 +846,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    rxLen = TxString.length();
                     sendSer(0);
                     heat = 0;
                     timeout = PING_TIMEOUT;
@@ -884,7 +861,6 @@ void MainWindow::RxData()
                 timer_on = true;
                 sprintf(buf, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
                 TxString = buf;
-                rxLen = TxString.length() + 38;
                 sendSer(38);
             }
             else
@@ -892,7 +868,6 @@ void MainWindow::RxData()
                 ui->statusBar->showMessage("Sweep (Holding)");
                 delay--;
                 status = hold;
-                rxLen = 0;
             }
             break;
         }
@@ -916,7 +891,6 @@ void MainWindow::RxData()
                         HV_Discharge_Timer =distime;
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        rxLen = TxString.length();
                         sendSer(0);
                         break;
                     }
@@ -956,7 +930,6 @@ void MainWindow::RxData()
                     delay = options.Delay;
                     status = Sweep_set;
                     timeout = ADC_READ_TIMEOUT;
-                    rxLen = 0;
                 }
                 else
                 {
@@ -975,7 +948,6 @@ void MainWindow::RxData()
                         ui->statusBar->showMessage("Sweep complete");
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        rxLen = TxString.length();
                         sendSer(0);
                     }
                 }
@@ -988,7 +960,6 @@ void MainWindow::RxData()
             if (HV_Discharge_Timer == (distime-1))
             {
                 TxString = "300000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
                 ui->HeaterProg->setValue(0);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -141,6 +141,11 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->Tabs->setCurrentIndex(0);
     //
     optimizer = new dr_optimize();
+
+    // Initalise the command response structure
+    CmdRsp.txState = TxIdle;
+    CmdRsp.rxState = RxIdle;
+    CmdRsp.timeout = 0;
 }
 
 MainWindow::~MainWindow()
@@ -317,9 +322,6 @@ void MainWindow::StopTheMachine()
     }
 }
 
-// Temporarily file global
-CommandResponse_t CmdRsp;
-
 void MainWindow::SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar)
 {
     static CommandResponse_t *pSendCmdRsp = NULL;
@@ -433,11 +435,9 @@ void MainWindow::readData()
     }
 }
 
-int MainWindow::RxPkt(QByteArray *response)
+int MainWindow::RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response)
 {
     int rxStatus = RXCONTINUE;
-    // Temporary
-    CommandResponse_t *pSendCmdRsp = &CmdRsp;
 
     if (pSendCmdRsp->timeout)
     {
@@ -609,7 +609,7 @@ void MainWindow::RxData()
 
     // ---------------------------------------------------
     // Check for the uTracer response
-    int RxCode = RxPkt(&response);
+    int RxCode = RxPkt(&CmdRsp, &response);
     // Check for timeout
     if (RxCode == RXTIMEOUT)
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -171,18 +171,19 @@ void MainWindow::SerialPortDiscovery()
     //get a list of ports
     serPortInfo = QSerialPortInfo::availablePorts();
     bool found = false;
+    qDebug() << "Requested serial port:" << comport;
     foreach (QSerialPortInfo port, serPortInfo) {
-        qDebug() << "SerialPortDiscovery: comport=" << comport <<  "available=" << port.portName();
-        if (comport.contains(port.portName()) and port.portName()!="") {
+        if (port.portName().isEmpty()) continue;
+        qDebug() << "Available serial port:" << port.portName();
+        if (!found && comport.contains(port.portName())) {
             found = true;
-            break;
+            qDebug() << "Using serial port:" << comport;
+            OpenComPort(&comport);
         }
     }
-    if (found) {
-        OpenComPort(&comport);
-    }
-    else  {
-        ui->statusBar->showMessage("The requested COM port was not found, try a different one.");
+    if (!found) {
+        qDebug() << "ERROR: Requested serial port:" << comport << "not found";
+        ui->statusBar->showMessage("The requested serial port was not found, try a different one.");
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1352,11 +1352,23 @@ bool MainWindow::ReadCalibration()
 {
     // Start with the default calibration values
     // Default to the first serial port (if present)
+    int i = 0;
+    int firstEntry = -1;
     QList<QSerialPortInfo> serPortInfo = QSerialPortInfo::availablePorts();
-    if (serPortInfo.count() > 0 && !serPortInfo.at(0).portName().isEmpty())
+    foreach (QSerialPortInfo port, serPortInfo)
+    {
+        if (!port.portName().isEmpty())
+        {
+            if (firstEntry == -1) firstEntry = i;
+            break;
+        }
+        i++;
+    }
+
+    if (firstEntry != -1)
     {
         // Use the first available serial port
-        comport = serPortInfo.at(0).portName();
+        comport = serPortInfo.at(firstEntry).portName();
     }
     else
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -91,13 +91,17 @@ MainWindow::MainWindow(QWidget *parent) :
     options.VgScale=1.0;
     portInUse = NULL;
     penList = new QList<QPen>;
-    status=Idle;
-    startSweep=0;
-    stop=false;
-    timer=NULL;
-    newMessage=false;
-    sendADC=false;
-    sendPing=false;
+
+    timer = NULL;
+    status = Idle;
+    startSweep = 0;
+    stop = false;
+    doStop = false;
+    doStart = false;
+    sendADC = false;
+    sendPing = false;
+    newMessage = false;
+
     VaADC=0;
     VsADC=0;
     VgADC=0;
@@ -253,7 +257,7 @@ void MainWindow::RequestOperation(Operation_t ReqOperation)
         case Stop:
         {
             qDebug() << "RequestOperation: Stop";
-            stop = true;
+            doStop = true;
             StartUpMachine();
             break;
         }
@@ -282,11 +286,8 @@ void MainWindow::RequestOperation(Operation_t ReqOperation)
         case Start:
         {
             qDebug() << "RequestOperation: Start";
-            if (SetUpSweepParams())
-            {
-                startSweep += 1;
-                StartUpMachine();
-            }
+            doStart = true;
+            StartUpMachine();
             break;
         }
         default:
@@ -620,17 +621,32 @@ void MainWindow::RxData()
     // Deal with user requests, communications must be idle
     if (RxCode == RXIDLE || RxCode == RXSUCCESS)
     {
-        if (sendADC == true)
+        if (doStop == true)
         {
-            qDebug() << "RxData: Action sendADC";
-            status = read_adc;
-            sendADC = false;
+            qDebug() << "RxData: Action doStop";
+            stop = true;
+            doStop = false;
         }
         else if (sendPing == true)
         {
             qDebug() << "RxData: Action sendPing";
             status = send_ping;
             sendPing = false;
+        }
+        else if (sendADC == true)
+        {
+            qDebug() << "RxData: Action sendADC";
+            status = read_adc;
+            sendADC = false;
+        }
+        else if (doStart == true)
+        {
+            qDebug() << "RxData: Action doStart";
+            if (SetUpSweepParams())
+            {
+                startSweep += 1;
+            }
+            doStart = false;
         }
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -100,7 +100,6 @@ MainWindow::MainWindow(QWidget *parent) :
     doStart = false;
     sendADC = false;
     sendPing = false;
-    newMessage = false;
 
     VaADC=0;
     VsADC=0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -175,8 +175,8 @@ void MainWindow::SerialPortDiscovery()
     portInUse->setFlowControl(QSerialPort::NoFlowControl);
     //10 bits????
 
-    //get a list of ports
-    serPortInfo = QSerialPortInfo::availablePorts();
+    // Get a list of serial ports
+    QList<QSerialPortInfo> serPortInfo = QSerialPortInfo::availablePorts();
     bool found = false;
     qDebug() << "Requested serial port:" << comport;
     foreach (QSerialPortInfo port, serPortInfo) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -579,6 +579,15 @@ void MainWindow::RxData()
     static QByteArray response;
     static int distime;
 
+    // ---------------------------------------------------
+    // Sanity check that the port is still OK
+    if (!portInUse || !portInUse->isOpen())
+    {
+        ui->statusBar->showMessage("ERROR: The serial port closed unexpectedly!");
+        StopTheMachine();
+        return;
+    }
+
     if (sendADC == true)
     {
         qDebug() << "RxData: Action sendADC";
@@ -596,14 +605,6 @@ void MainWindow::RxData()
         SendEndMeasurementCommand(&CmdRsp);
         status = WaitPing;
         sendPing = false;
-        return;
-    }
-
-    // ---------------------------------------------------
-    // Sanity check that the port is still OK
-    if (!portInUse || !portInUse->isOpen())
-    {
-        ui->statusBar->showMessage("COM port was closed, exit and restart.");
         return;
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -335,6 +335,7 @@ void MainWindow::RxData()
 
     if (sendADC == true)
     {
+        qDebug() << "RxData: Action sendADC";
         cmd = TxString = "500000000000000000";
         rxLen = TxString.length() + 38;
         heat = 0;
@@ -348,6 +349,7 @@ void MainWindow::RxData()
 
     if (sendPing == true)
     {
+        qDebug() << "RxData: Action sendPing";
         cmd = TxString = "300000000000000000";
         rxLen = TxString.length();
         heat = 0;
@@ -373,6 +375,7 @@ void MainWindow::RxData()
     // Check for timeout
     if (RxCode == RXTIMEOUT && timer_on)
     {
+        qDebug() << "RxData: Action RxCode RXTIMEOUT";
         ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
         TxString = "300000000000000000";
         response.clear();
@@ -387,6 +390,7 @@ void MainWindow::RxData()
     // Check for invalid rsponse
     if (RxCode == RXINVALID)
     {
+        qDebug() << "RxData: Action RxCode RXINVALID";
         ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
         response.clear();
         rxLen = 0;
@@ -398,6 +402,8 @@ void MainWindow::RxData()
     // ---------------------------------------------------
     // Main state machine
     // Check state
+    qDebug() << "RxData: status:" << status << ":" << status_name[status];
+
     switch (status)
     {
         case Idle:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -185,7 +185,7 @@ void MainWindow::SerialPortDiscovery()
         if (!found && comport.contains(port.portName())) {
             found = true;
             qDebug() << "Using serial port:" << comport;
-            OpenComPort(&comport);
+            OpenComPort(&comport, false);
         }
     }
     if (!found) {
@@ -194,7 +194,7 @@ void MainWindow::SerialPortDiscovery()
     }
 }
 
-void MainWindow::OpenComPort(const QString *portName)
+void MainWindow::OpenComPort(const QString *portName, bool updateCalFile)
 {
     qDebug() <<"MainWindow::OpenComPort";
     //Close open port
@@ -212,7 +212,8 @@ void MainWindow::OpenComPort(const QString *portName)
     {
         connect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         msg = QString("Port %1 opened").arg(comport);
-        SaveCalFile(); //Update cal file with new port info
+        if(updateCalFile)
+            SaveCalFile(); //Update cal file with new port info
     }
     else
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -317,7 +317,7 @@ int MainWindow::RxPkt(int len, QByteArray * cmd, QByteArray * response)
     return RXCONTINUE;
 }
 //---------------------------------------------
-//The main control process
+// The main control process
 void MainWindow::RxData()
 {
     static int time;
@@ -333,190 +333,209 @@ void MainWindow::RxData()
     static QByteArray response;
     static int distime;
 
-    if (sendADC==true)
+    if (sendADC == true)
     {
-        cmd = TxString="500000000000000000";
-        rxLen = TxString.length()+38;
-        heat=0;
+        cmd = TxString = "500000000000000000";
+        rxLen = TxString.length() + 38;
+        heat = 0;
         sendSer();
-        sendADC=false;
-        status=wait_adc;
+        sendADC = false;
+        status = wait_adc;
         timeout = PING_TIMEOUT;
-        timer_on=true;
+        timer_on = true;
         return;
     }
-    if (sendPing==true)
+
+    if (sendPing == true)
     {
-        cmd = TxString="300000000000000000";
+        cmd = TxString = "300000000000000000";
         rxLen = TxString.length();
-        heat=0;
+        heat = 0;
         sendSer();
-        sendPing=false;
-        status=WaitPing;
+        sendPing = false;
+        status = WaitPing;
         timeout = PING_TIMEOUT;
-        timer_on=true;
+        timer_on = true;
         return;
     }
+
     // ---------------------------------------------------
-    // sanity check that the port is still OK
+    // Sanity check that the port is still OK
     if (!portInUse || !portInUse->isOpen())
     {
         ui->statusBar->showMessage("COM port was closed, exit and restart.");
         return;
     }
+
     // ---------------------------------------------------
     // Check for the uTracer response
     int RxCode = RxPkt(rxLen, &cmd, &response);
     // Check for timeout
-    if (RxCode==RXTIMEOUT && timer_on)
+    if (RxCode == RXTIMEOUT && timer_on)
     {
         ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
-        TxString="300000000000000000";
+        TxString = "300000000000000000";
         response.clear();
         cmd = TxString;
         rxLen = TxString.length();
         sendSer();
-        timer_on= false;
+        timer_on = false;
         status = Idle;
         return;
     }
-    //Check for invalid rsponse
-    if (RxCode==RXINVALID)
+
+    // Check for invalid rsponse
+    if (RxCode == RXINVALID)
     {
         ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
         response.clear();
         rxLen = 0;
-        timer_on= false;
+        timer_on = false;
         status = Idle;
         return;
     }
+
     // ---------------------------------------------------
-    //Main state machine
-    //Check state
-    switch (status) {
-        case Idle: {
+    // Main state machine
+    // Check state
+    switch (status)
+    {
+        case Idle:
+        {
             rxLen = 0;
-            timer_on=false;
-            time=0;
-            //ui->statusBar->showMessage("Ready");
-            if (startSweep>0)
+            timer_on = false;
+            time = 0;
+
+            if (startSweep > 0)
             {
-                startSweep-=1;
+                startSweep -= 1;
                 StoreData(false); //Init data store
-                VsStep=0;
-                VgStep=0;
-                VaStep=0;
-                curve=0;
-                if (heat!=HEAT_CNT_MAX) {
+                VsStep = 0;
+                VgStep = 0;
+                VaStep = 0;
+                curve = 0;
+
+                if (heat != HEAT_CNT_MAX)
+                {
                     ui->statusBar->showMessage("Heating setup");
                     status = Heating_wait00;
-                    heat=0;
+                    heat = 0;
                     ui->HeaterProg->setValue(1);
                 }
-                else {
+                else
+                {
                     ui->statusBar->showMessage("Sweep setup");
                     status = Sweep_set;
                     delay=options.Delay;
                 }
+
                 ui->CaptureProg->setValue(1);
-                TxString="0000000000";
+                TxString = "0000000000";
                 ::snprintf(buf, 3, "%02X", lim[options.Ilimit]);
-                TxString+=buf;
+                TxString += buf;
                 ::snprintf(buf, 3, "%02X", avg[options.AvgNum]);
-                TxString+=buf;
+                TxString += buf;
                 ::snprintf(buf, 3, "%02X", Ir[options.IsRange]);
-                TxString+=buf;
+                TxString += buf;
                 ::snprintf(buf, 3, "%02X", Ir[options.IaRange]);
-                TxString+=buf;
-                cmd =TxString;
-                rxLen=18;
+                TxString += buf;
+                cmd = TxString;
+                rxLen = 18;
                 sendSer();
-                timer_on=true;
+                timer_on = true;
                 timeout = PING_TIMEOUT;
             }
             break;
         }
-        case WaitPing: {
-            //qDebug()<<"WaitPing";
-            if (RxCode==RXSUCCESS) {
-                rxLen=0;
-                cmd="";
-                status=Idle;
+        case WaitPing:
+        {
+            if (RxCode == RXSUCCESS)
+            {
+                rxLen = 0;
+                cmd = "";
+                status = Idle;
                 ui->statusBar->showMessage("Ping OK");
-                timer_on=false;
+                timer_on = false;
                 timeout = PING_TIMEOUT;
-           }
-            break;
-        }
-        case wait_adc: {
-            //qDebug()<<"Wait_adc";
-            if (RxCode==RXSUCCESS) {
-                saveADCInfo(&response);
-                rxLen=0;
-                cmd="";
-                status=Idle;
-                ui->statusBar->showMessage("Ready");
-                timer_on=false;
-                timeout = PING_TIMEOUT;
-           }
-            break;
-        }
-        case Heating_wait00: {
-            //qDebug()<<"Heating_wait00";
-            if (RxCode==RXSUCCESS) {
-                ui->statusBar->showMessage("Heating, get ADC info");
-                status=Heating_wait_adc;
-                cmd = TxString="500000000000000000";
-                rxLen = TxString.length()+38;
-                sendSer();
-                timer_on=true;
-                timeout=PING_TIMEOUT;
             }
             break;
         }
-        case Heating_wait_adc: {
-            //qDebug()<<"Heating_wait_adc";
-            if (RxCode==RXSUCCESS) {
+        case wait_adc:
+        {
+            if (RxCode == RXSUCCESS)
+            {
+                saveADCInfo(&response);
+                rxLen = 0;
+                cmd = "";
+                status = Idle;
+                ui->statusBar->showMessage("Ready");
+                timer_on = false;
+                timeout = PING_TIMEOUT;
+            }
+            break;
+        }
+        case Heating_wait00:
+        {
+            if (RxCode == RXSUCCESS)
+            {
+                ui->statusBar->showMessage("Heating, get ADC info");
+                status = Heating_wait_adc;
+                cmd = TxString = "500000000000000000";
+                rxLen = TxString.length() + 38;
+                sendSer();
+                timer_on = true;
+                timeout = PING_TIMEOUT;
+            }
+            break;
+        }
+        case Heating_wait_adc:
+        {
+            if (RxCode == RXSUCCESS)
+            {
                 VgNow=ui->VgStart->text().toFloat();
                 saveADCInfo(&response);
-                heat=0;
-                status=Heating;
+                heat = 0;
+                status = Heating;
                 ui->statusBar->showMessage("Heating");
-                TxString="400000000000000000";
+                TxString = "400000000000000000";
                 rxLen = TxString.length();
                 cmd = TxString;
                 sendSer();
-                timer_on=true;
+                timer_on = true;
                 timeout = PING_TIMEOUT;
-                heat=1;
+                heat = 1;
             }
             break;
         }
-        case Heating: {
-            //qDebug()<<"Heating";
-            if (stop) {
+        case Heating:
+        {
+            if (stop)
+            {
                 stop = false;
-                status=HeatOff;
-                HV_Discharge_Timer =0;
+                status = HeatOff;
+                HV_Discharge_Timer = 0;
                 ui->HeaterProg->setValue(0);
                 ui->statusBar->showMessage("Heater off");
-                TxString="400000000000000000";
+                TxString = "400000000000000000";
                 cmd = TxString;
                 rxLen = TxString.length();
                 sendSer();
-                heat=0;
-                timeout =PING_TIMEOUT;
-                timer_on=true;
+                heat = 0;
+                timeout = PING_TIMEOUT;
+                timer_on = true;
             }
-            else if (RxCode==RXSUCCESS) {
-                if (heat<=HEAT_CNT_MAX) {
-                    if (startSweep > 0) {
-                        startSweep -=1;
+            else if (RxCode == RXSUCCESS)
+            {
+                if (heat <= HEAT_CNT_MAX)
+                {
+                    if (startSweep > 0)
+                    {
+                        startSweep -= 1;
                         heat = HEAT_CNT_MAX;
                     }
-                    ui->HeaterProg->setValue((100*heat)/HEAT_CNT_MAX);
+                    ui->HeaterProg->setValue((100 * heat) / HEAT_CNT_MAX);
                     VfADC = GetVf((float)heat);
-                    if (VfADC>1023) VfADC=1023;
+                    if (VfADC > 1023) VfADC = 1023;
                     ::snprintf(buf, 19, "40000000000000%04X", VfADC);
                     TxString = buf;
                     rxLen = TxString.length();
@@ -525,211 +544,215 @@ void MainWindow::RxData()
                     sendSer();
                     heat++;
                 }
-                else {
-                    //qDebug()<<"Heating Done";
+                else
+                {
                     ui->HeaterProg->setValue(100);
                     timeout = PING_TIMEOUT;
-                    status=heat_done;
-                    timer_on=false;
-                    rxLen=0;
-                    cmd="";
+                    status = heat_done;
+                    timer_on = false;
+                    rxLen = 0;
+                    cmd = "";
                 }
             }
             break;
         }
-        case heat_done: {
-            //qDebug()<<"Heat_done";
-            QString m = QString("Press 'start' when ready; heating for %1 secs").arg(time/1000);
-            time+=TIMER_SET;
+        case heat_done:
+        {
+            QString m = QString("Press 'start' when ready; heating for %1 secs").arg(time / 1000);
+            time += TIMER_SET;
             ui->statusBar->showMessage(m);
-            delay=options.Delay;
+            delay = options.Delay;
             if (stop)
             {
                 stop = false;
-                status=HeatOff;
-                HV_Discharge_Timer =0;
-                cmd=TxString="400000000000000000";
+                status = HeatOff;
+                HV_Discharge_Timer = 0;
+                cmd=TxString = "400000000000000000";
                 rxLen=TxString.length();
                 sendSer();
                 ui->CaptureProg->setValue(0);
-                timeout =PING_TIMEOUT;
-                timer_on=true;
+                timeout = PING_TIMEOUT;
+                timer_on = true;
             }
-            else if (startSweep>0 || time/1000==HEAT_WAIT_SECS) {
-                startSweep=0;
-                if (dataStore->length()>0) dataStore->clear();
-                rxLen=0;
-                cmd="";
+            else if (startSweep > 0 || time / 1000 == HEAT_WAIT_SECS)
+            {
+                startSweep = 0;
+                if (dataStore->length() > 0) dataStore->clear();
+                rxLen = 0;
+                cmd = "";
                 CreateTestVectors();
-                curve=0;
-                status=Sweep_set;
+                curve = 0;
+                status = Sweep_set;
             }
             break;
         }
-        case Sweep_set: {
+        case Sweep_set:
+        {
             if (stop)
             {
-                //qDebug() << "Sweep set(stop)";
                 stop = false;
-                status=HeatOff;
+                status = HeatOff;
                 float v = VaNow > VsNow ? VaNow : VsNow;
-                distime =(int)(DISTIME * v/400);
-                HV_Discharge_Timer =distime;
+                distime = (int)(DISTIME * v / 400);
+                HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
-                cmd = TxString="400000000000000000";
+                cmd = TxString = "400000000000000000";
                 rxLen = TxString.length();
                 sendSer();
                 ui->CaptureProg->setValue(0);
-                timeout =PING_TIMEOUT;
-                timer_on=true;
+                timeout = PING_TIMEOUT;
+                timer_on = true;
             }
-            else if (delay==0) {
-                //qDebug() << "Sweep set";
+            else if (delay == 0)
+            {
                 status=hold_ack;
                 ui->statusBar->showMessage("Sweep Measure");
                 VaNow = sweepList->at(curve).Va;
                 VsNow = sweepList->at(curve).Vs;
                 VgNow = sweepList->at(curve).Vg;
-                //qDebug() << "a=" << VaNow << "s=" << VsNow << "g=" << VgNow;
-                //qDebug() << "VaStep=" << VaStep << "VsStep=" << VsStep << "VgStep=" << VgStep;
-                VaADC = GetVa( VaNow );
-                VsADC = GetVs( VsNow );
-                VgADC = GetVg( VgNow );
+                VaADC = GetVa(VaNow);
+                VsADC = GetVs(VsNow);
+                VgADC = GetVg(VgNow);
                 VfADC = GetVf( HEAT_CNT_MAX );
-                status=Sweep_adc;
-                timeout=ADC_READ_TIMEOUT;
-                timer_on=true;
-                ::snprintf(buf,19,"10%04X%04X%04X%04X",VaADC,VsADC,VgADC,VfADC );
-                cmd = TxString=buf;
-                rxLen=TxString.length()+38;
+                status = Sweep_adc;
+                timeout = ADC_READ_TIMEOUT;
+                timer_on = true;
+                ::snprintf(buf, 19, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC );
+                cmd = TxString= buf;
+                rxLen= TxString.length() + 38;
                 sendSer();
             }
-            else {
+            else
+            {
                 ui->statusBar->showMessage("Sweep hold");
                 VaNow = sweepList->at(curve).Va;
                 VsNow = sweepList->at(curve).Vs;
                 VgNow = sweepList->at(curve).Vg;
-                if (VaNow>425 || VsNow>425) {
+                if (VaNow > 425 || VsNow > 425)
+                {
                     ui->statusBar->showMessage("Internal Error: Vaor Vs excessive");
                     stop = false;
-                    status=HeatOff;
+                    status = HeatOff;
                     float v = VaNow > VsNow ? VaNow : VsNow;
-                    distime =(int)(DISTIME * v/400);
-                    HV_Discharge_Timer =distime;
+                    distime = (int)(DISTIME * v / 400);
+                    HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
-                    TxString="400000000000000000";
+                    TxString = "400000000000000000";
                     cmd = TxString;
                     rxLen = TxString.length();
                     sendSer();
                     heat=0;
-                    timeout =PING_TIMEOUT;
-                    timer_on=true;
+                    timeout = PING_TIMEOUT;
+                    timer_on = true;
                     break;
                 }
-//                qDebug() << "a=" << VaNow << "s=" << VsNow << "g=" << VgNow;
-//                qDebug() << "VaStep=" << VaStep << "VsStep=" << VsStep << "VgStep=" << VgStep;
-                VaADC = GetVa( VaNow );
-                VsADC = GetVs( VsNow );
-                VgADC = GetVg( VgNow );
-                VfADC = GetVf( HEAT_CNT_MAX );
-                status=hold_ack;
-                timeout=ADC_READ_TIMEOUT + options.Delay;
-                timer_on=true;
-                sprintf(buf,"20%04X%04X%04X%04X",VaADC,VsADC,VgADC,VfADC );
-                cmd = TxString=buf;
-                rxLen=TxString.length();
+                VaADC = GetVa(VaNow);
+                VsADC = GetVs(VsNow);
+                VgADC = GetVg(VgNow);
+                VfADC = GetVf(HEAT_CNT_MAX);
+                status = hold_ack;
+                timeout = ADC_READ_TIMEOUT + options.Delay;
+                timer_on = true;
+                sprintf(buf, "20%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
+                cmd = TxString = buf;
+                rxLen = TxString.length();
                 sendSer();
             }
             break;
         }
-        case hold_ack: {
-            status=hold;
-            timer_on=false;
-            rxLen=0;
-            cmd="";
+        case hold_ack:
+        {
+            status = hold;
+            timer_on = false;
+            rxLen = 0;
+            cmd = "";
             break;
         }
-        case hold : {
+        case hold:
+        {
             if (stop)
             {
                 stop = false;
-                status=HeatOff;
+                status = HeatOff;
                 float v = VaNow > VsNow ? VaNow : VsNow;
-                distime =(int)(DISTIME * v/400);
-                HV_Discharge_Timer =distime;
+                distime = (int)(DISTIME * v / 400);
+                HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
-                TxString="400000000000000000";
+                TxString = "400000000000000000";
                 cmd = TxString;
                 rxLen = TxString.length();
                 sendSer();
-                heat=0;
-                timeout =PING_TIMEOUT;
-                timer_on=true;
+                heat = 0;
+                timeout = PING_TIMEOUT;
+                timer_on = true;
             }
-            else if (delay==0)
+            else if (delay == 0)
             {
-                status=Sweep_adc;
+                status = Sweep_adc;
                 ui->statusBar->showMessage("Sweep (set measurement parameters)");
-                //qDebug() << "a=" << VaNow << "s=" << VsNow << "g=" << VgNow;
-                //qDebug() << "VaStep=" << VaStep << "VsStep=" << VsStep << "VgStep=" << VgStep;
                 VaNow = sweepList->at(curve).Va;
                 VsNow = sweepList->at(curve).Vs;
                 VgNow = sweepList->at(curve).Vg;
-                if (VaNow>425 || VsNow>425) {
+                if (VaNow > 425 || VsNow > 425)
+                {
                     ui->statusBar->showMessage("Internal Error: Va or Vs excessive");
                     stop = false;
-                    status=HeatOff;
+                    status = HeatOff;
                     float v = VaNow > VsNow ? VaNow : VsNow;
-                    distime =(int)(DISTIME * v/400);
-                    HV_Discharge_Timer =distime;
+                    distime = (int)(DISTIME * v / 400);
+                    HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
-                    TxString="400000000000000000";
+                    TxString = "400000000000000000";
                     cmd = TxString;
                     rxLen = TxString.length();
                     sendSer();
-                    heat=0;
-                    timeout =PING_TIMEOUT;
-                    timer_on=true;
+                    heat = 0;
+                    timeout = PING_TIMEOUT;
+                    timer_on = true;
                     break;
                 }
 
-                VaADC = GetVa( VaNow );
-                VsADC = GetVs( VsNow );
-                VgADC = GetVg( VgNow );
-                VfADC = GetVf( HEAT_CNT_MAX );
-                timeout=ADC_READ_TIMEOUT;
-                timer_on=true;
-                sprintf(buf,"10%04X%04X%04X%04X",VaADC,VsADC,VgADC,VfADC );
-                cmd = TxString=buf;
-                rxLen = TxString.length()+38;
+                VaADC = GetVa(VaNow);
+                VsADC = GetVs(VsNow);
+                VgADC = GetVg(VgNow);
+                VfADC = GetVf(HEAT_CNT_MAX);
+                timeout = ADC_READ_TIMEOUT;
+                timer_on = true;
+                sprintf(buf, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
+                cmd = TxString = buf;
+                rxLen = TxString.length() + 38;
                 sendSer();
             }
-            else {
+            else
+            {
                 ui->statusBar->showMessage("Sweep (Holding)");
-                //qDebug() << "delay=" << delay;
                 delay--;
-                status=hold;
-                rxLen =0;
-                cmd ="";
+                status = hold;
+                rxLen = 0;
+                cmd = "";
             }
             break;
         }
-        case Sweep_adc: {
-            if (RxCode==RXSUCCESS) {
+        case Sweep_adc:
+        {
+            if (RxCode == RXSUCCESS)
+            {
                 //check current limit
                 saveADCInfo(&response);
                 StoreData(true); //Add to data store
-                if (response.mid(0,2)=="11") {
+                if (response.mid(0,2) == "11")
+                {
                     ui->statusBar->showMessage("WARNING: Current Limit Hit");
                     qDebug() << "Sweep_adc: Current Limit Hit";
-                    if (options.AbortOnLimit==true) {
+                    if (options.AbortOnLimit == true)
+                    {
                         qDebug() << "Sweep_adc: Current Limit Abort";
-                        status=HeatOff;
+                        status = HeatOff;
                         float v = VaNow > VsNow ? VaNow : VsNow;
-                        distime =(int)(DISTIME * v/400);
+                        distime =(int)(DISTIME * v / 400);
                         HV_Discharge_Timer =distime;
                         ui->CaptureProg->setValue(100);
-                        TxString="400000000000000000";
+                        TxString = "400000000000000000";
                         cmd = TxString;
                         rxLen = TxString.length();
                         sendSer();
@@ -737,41 +760,46 @@ void MainWindow::RxData()
                     }
                 }
                 curve++;
-                bool done=false;
-                if ( (power > tubeData.powerLim) && !ui->checkQuickTest->isChecked()) {
-                    while (!done) {
-                        if (sweepList->at(curve).Va >= VaNow) {
-                            results.Ia=-1; // mark as ignore
+                bool done = false;
+                if ((power > tubeData.powerLim) && !ui->checkQuickTest->isChecked())
+                {
+                    while (!done)
+                    {
+                        if (sweepList->at(curve).Va >= VaNow)
+                        {
+                            results.Ia = -1; // mark as ignore
                             dataStore->append(results);
                             curve++; //skip high power points
-                            if (curve == sweepList->length()) {
-                                done =true;
-                                if ( (dataStore->length()>5) && ui->TubeType->currentText()!=NONE) {
-                                        optimizer->Optimize(dataStore, ui->TubeType->currentIndex(), 1, VaSteps, VsSteps, VgSteps);
-                                        updateLcdsWithModel();
-                                        RePlot(dataStore);
+                            if (curve == sweepList->length())
+                            {
+                                done = true;
+                                if ((dataStore->length() > 5) && ui->TubeType->currentText() != NONE)
+                                {
+                                    optimizer->Optimize(dataStore, ui->TubeType->currentIndex(), 1, VaSteps, VsSteps, VgSteps);
+                                    updateLcdsWithModel();
+                                    RePlot(dataStore);
                                 }
                             }
                         }
-                        else done=true;
+                        else done = true;
 
                     }
                 }
-                if (curve < sweepList->length()) {
-                    int progress=(100*curve)/sweepList->length();
+                if (curve < sweepList->length())
+                {
+                    int progress = (100 * curve) / sweepList->length();
                     ui->CaptureProg->setValue(progress);
                     QString msg = QString("Sweep %1 % done").arg(progress);
                     ui->statusBar->showMessage(msg);
                     delay = options.Delay;
-                    //qDebug() << "From Sweep_adc to Sweep_set";
-                    status=Sweep_set;
-                    timeout=ADC_READ_TIMEOUT;
-                    rxLen=0;
-                    cmd="";
+                    status = Sweep_set;
+                    timeout = ADC_READ_TIMEOUT;
+                    rxLen = 0;
+                    cmd = "";
                 }
                 else
                 {
-                    if (startSweep>0) //skip re-heating
+                    if (startSweep > 0) //skip re-heating
                     {
                         status = heat_done;
                         ui->statusBar->showMessage("Sweep complete");
@@ -779,13 +807,13 @@ void MainWindow::RxData()
                     }
                     else
                     {
-                        status=HeatOff;
+                        status = HeatOff;
                         float v = VaNow > VsNow ? VaNow : VsNow;
-                        distime =(int)(DISTIME * v/400);
-                        HV_Discharge_Timer =distime;
+                        distime = (int)(DISTIME * v / 400);
+                        HV_Discharge_Timer = distime;
                         ui->statusBar->showMessage("Sweep complete");
                         ui->CaptureProg->setValue(100);
-                        TxString="400000000000000000";
+                        TxString = "400000000000000000";
                         cmd = TxString;
                         rxLen = TxString.length();
                         sendSer();
@@ -794,31 +822,34 @@ void MainWindow::RxData()
             }
             break;
         }
-        case HeatOff: {
-            //qDebug() << "HeatOff";
+        case HeatOff:
+        {
             if (HV_Discharge_Timer>0) HV_Discharge_Timer--;
-            if (HV_Discharge_Timer==(distime-1)) {
-                cmd  = TxString="300000000000000000";
+            if (HV_Discharge_Timer == (distime-1))
+            {
+                cmd = TxString = "300000000000000000";
                 rxLen = TxString.length();
                 sendSer();
-                heat=0;
+                heat = 0;
                 ui->HeaterProg->setValue(0);
-                timeout =PING_TIMEOUT;
-                if (ui->checkAutoNumber->isChecked()) {
+                timeout = PING_TIMEOUT;
+                if (ui->checkAutoNumber->isChecked())
+                {
                     if (!ui->checkQuickTest->isChecked()) on_actionSave_plot_triggered();
                     on_actionSave_Data_triggered();
                     int fn = ui->AutoNumber->text().toInt(&ok);
-                    ui->AutoNumber->setText(QString::number(fn+1));
+                    ui->AutoNumber->setText(QString::number(fn + 1));
                 }
-                timer_on=true;
+                timer_on = true;
 
-            } else if (HV_Discharge_Timer==0) {
+            } else if (HV_Discharge_Timer==0)
+            {
                 ui->statusBar->showMessage("Ready");
                 status=Idle;
             }
             else
             {
-                timeout =PING_TIMEOUT;
+                timeout = PING_TIMEOUT;
                 QString msg = QString("Countdown for HV to discharge: %1").arg(HV_Discharge_Timer);
                 ui->statusBar->showMessage(msg);
             }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -143,32 +143,6 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->Tabs->setCurrentIndex(0);
     //
     optimizer = new dr_optimize();
-
-    //get paths and define file names
-    //appDir = QCoreApplication.applicationDirPath()
-    uTmaxDir = QDir::homePath();
-    uTmaxDir.append("/uTmax_files/");
-    qDebug() << "Home directory:" << uTmaxDir;
-    QDir dir(uTmaxDir);
-    if(!dir.exists())
-    {
-        qDebug() << "ERROR: Home directory does not exist:" << uTmaxDir;
-        std::exit(EXIT_FAILURE);
-    }
-
-    // Read the default tube data file or ask for the file
-    dataFileName = uTmaxDir;
-    dataFileName.append("data.csv");
-    if (!ReadDataFile())
-        std::exit(EXIT_FAILURE);
-
-    // Read the calibration file or create a fresh file
-    calFileName = uTmaxDir;
-    calFileName.append("cal.txt");
-    if (!ReadCalibration())
-        std::exit(EXIT_FAILURE);
-
-    SerialPortDiscovery();
 }
 
 MainWindow::~MainWindow()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -222,8 +222,8 @@ bool MainWindow::OpenComPort(const QString *portName, bool updateCalFile)
     }
     ui->statusBar->showMessage(msg);
 
-    // Start the machine
-    if (openResult) StartUpMachine();
+    // Probe for the uTracer being present
+    if (openResult) RequestOperation((Operation_t) Probe);
 
     return(openResult);
 }
@@ -243,16 +243,63 @@ bool MainWindow::CloseComPort()
     }
 }
 
+void MainWindow::RequestOperation(Operation_t ReqOperation)
+{
+    switch (ReqOperation)
+    {
+        case Stop:
+        {
+            qDebug() << "RequestOperation: Stop";
+            stop = true;
+            StartUpMachine();
+            break;
+        }
+        case Probe:
+        {
+            qDebug() << "RequestOperation: Probe";
+            ui->statusBar->showMessage("Starting up...");
+            sendADC = true;
+            StartUpMachine();
+            break;
+        }
+        case Ping:
+        {
+            qDebug() << "RequestOperation: Ping";
+            sendPing = true;
+            StartUpMachine();
+            break;
+        }
+        case ReadADC:
+        {
+            qDebug() << "RequestOperation: ReadADC";
+            sendADC = true;
+            StartUpMachine();
+            break;
+        }
+        case Start:
+        {
+            qDebug() << "RequestOperation: Start";
+            if (SetUpSweepParams())
+            {
+                startSweep += 1;
+                StartUpMachine();
+            }
+            break;
+        }
+        default:
+        {
+            qDebug() << "ERROR: RequestOperation: Unrecognised operation:" << ReqOperation;
+            break;
+        }
+    }
+}
+
 void MainWindow::StartUpMachine()
 {
     // Start up the machine
     if (!timer)
     {
         qDebug() << "StartUpMachine: Starting up the machine!";
-        ui->statusBar->showMessage("Starting up...");
-        timer_on = true;
-        timeout = PING_TIMEOUT;
-        sendADC = true;
         timer = new QTimer(this);
         connect(timer, SIGNAL(timeout()), this, SLOT(RxData()));
         timer->start(TIMER_SET);
@@ -447,6 +494,11 @@ void MainWindow::RxData()
                 sendSer();
                 timer_on = true;
                 timeout = PING_TIMEOUT;
+            }
+            else
+            {
+                // All operations completed so stop
+                StopTheMachine();
             }
             break;
         }
@@ -2314,10 +2366,9 @@ bool MainWindow::SetUpSweepParams() {
     return true;
 }
 
-void MainWindow::on_Start_clicked() {
-    if (!SetUpSweepParams()) return;
-
-    startSweep+=1;
+void MainWindow::on_Start_clicked()
+{
+    RequestOperation((Operation_t) Start);
 }
 void MainWindow::CreateTestVectors()
 {
@@ -2439,8 +2490,9 @@ void MainWindow::CreateTestVectors()
 void MainWindow::on_VsStart_editingFinished() {
 }
 
-void MainWindow::on_Stop_clicked() {
-    stop=true;
+void MainWindow::on_Stop_clicked()
+{
+    RequestOperation((Operation_t) Stop);
 }
 
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -498,14 +498,13 @@ void MainWindow::RxData()
     static int lim[]={0x8f, 0x8d, 0xad, 0xab, 0x84, 0xa4, 0xa2, 0xa1, 0x80, 0x00};
     static int avg[]={0x40, 1, 2, 4, 8, 16, 32, 0x40};
     static int Ir[]={8,1,2,3,4,5,6,7};
-    static QByteArray cmd;
     static QByteArray response;
     static int distime;
 
     if (sendADC == true)
     {
         qDebug() << "RxData: Action sendADC";
-        cmd = TxString = "500000000000000000";
+        TxString = "500000000000000000";
         rxLen = TxString.length() + 38;
         heat = 0;
         sendSer(38);
@@ -519,7 +518,7 @@ void MainWindow::RxData()
     if (sendPing == true)
     {
         qDebug() << "RxData: Action sendPing";
-        cmd = TxString = "300000000000000000";
+        TxString = "300000000000000000";
         rxLen = TxString.length();
         heat = 0;
         sendSer(0);
@@ -548,7 +547,6 @@ void MainWindow::RxData()
         ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
         TxString = "300000000000000000";
         response.clear();
-        cmd = TxString;
         rxLen = TxString.length();
         sendSer(0);
         timer_on = false;
@@ -614,7 +612,6 @@ void MainWindow::RxData()
                 TxString += buf;
                 ::snprintf(buf, 3, "%02X", Ir[options.IaRange]);
                 TxString += buf;
-                cmd = TxString;
                 rxLen = 18;
                 sendSer(0);
                 timer_on = true;
@@ -632,7 +629,6 @@ void MainWindow::RxData()
             if (RxCode == RXSUCCESS)
             {
                 rxLen = 0;
-                cmd = "";
                 status = Idle;
                 ui->statusBar->showMessage("Ping OK");
                 timer_on = false;
@@ -646,7 +642,6 @@ void MainWindow::RxData()
             {
                 saveADCInfo(&response);
                 rxLen = 0;
-                cmd = "";
                 status = Idle;
                 ui->statusBar->showMessage("Ready");
                 timer_on = false;
@@ -660,7 +655,7 @@ void MainWindow::RxData()
             {
                 ui->statusBar->showMessage("Heating, get ADC info");
                 status = Heating_wait_adc;
-                cmd = TxString = "500000000000000000";
+                TxString = "500000000000000000";
                 rxLen = TxString.length() + 38;
                 sendSer(38);
                 timer_on = true;
@@ -679,7 +674,6 @@ void MainWindow::RxData()
                 ui->statusBar->showMessage("Heating");
                 TxString = "400000000000000000";
                 rxLen = TxString.length();
-                cmd = TxString;
                 sendSer(0);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -697,7 +691,6 @@ void MainWindow::RxData()
                 ui->HeaterProg->setValue(0);
                 ui->statusBar->showMessage("Heater off");
                 TxString = "400000000000000000";
-                cmd = TxString;
                 rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
@@ -719,7 +712,6 @@ void MainWindow::RxData()
                     ::snprintf(buf, 19, "40000000000000%04X", VfADC);
                     TxString = buf;
                     rxLen = TxString.length();
-                    cmd = TxString;
                     timeout = PING_TIMEOUT;
                     sendSer(0);
                     heat++;
@@ -730,7 +722,6 @@ void MainWindow::RxData()
                     status = heat_done;
                     timer_on = false;
                     rxLen = 0;
-                    cmd = "";
                 }
             }
             break;
@@ -746,7 +737,7 @@ void MainWindow::RxData()
                 stop = false;
                 status = HeatOff;
                 HV_Discharge_Timer = 0;
-                cmd=TxString = "400000000000000000";
+                TxString = "400000000000000000";
                 rxLen=TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
@@ -758,7 +749,6 @@ void MainWindow::RxData()
                 startSweep = 0;
                 if (dataStore->length() > 0) dataStore->clear();
                 rxLen = 0;
-                cmd = "";
                 CreateTestVectors();
                 curve = 0;
                 status = Sweep_set;
@@ -775,7 +765,7 @@ void MainWindow::RxData()
                 distime = (int)(DISTIME * v / 400);
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
-                cmd = TxString = "400000000000000000";
+                TxString = "400000000000000000";
                 rxLen = TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
@@ -797,7 +787,7 @@ void MainWindow::RxData()
                 timeout = ADC_READ_TIMEOUT;
                 timer_on = true;
                 ::snprintf(buf, 19, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC );
-                cmd = TxString= buf;
+                TxString= buf;
                 rxLen= TxString.length() + 38;
                 sendSer(38);
             }
@@ -817,7 +807,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    cmd = TxString;
                     rxLen = TxString.length();
                     sendSer(0);
                     heat=0;
@@ -833,7 +822,7 @@ void MainWindow::RxData()
                 timeout = ADC_READ_TIMEOUT + options.Delay;
                 timer_on = true;
                 sprintf(buf, "20%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
-                cmd = TxString = buf;
+                TxString = buf;
                 rxLen = TxString.length();
                 sendSer(0);
             }
@@ -844,7 +833,6 @@ void MainWindow::RxData()
             status = hold;
             timer_on = false;
             rxLen = 0;
-            cmd = "";
             break;
         }
         case hold:
@@ -858,7 +846,6 @@ void MainWindow::RxData()
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
                 TxString = "400000000000000000";
-                cmd = TxString;
                 rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
@@ -882,7 +869,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    cmd = TxString;
                     rxLen = TxString.length();
                     sendSer(0);
                     heat = 0;
@@ -898,7 +884,7 @@ void MainWindow::RxData()
                 timeout = ADC_READ_TIMEOUT;
                 timer_on = true;
                 sprintf(buf, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
-                cmd = TxString = buf;
+                TxString = buf;
                 rxLen = TxString.length() + 38;
                 sendSer(38);
             }
@@ -908,7 +894,6 @@ void MainWindow::RxData()
                 delay--;
                 status = hold;
                 rxLen = 0;
-                cmd = "";
             }
             break;
         }
@@ -932,7 +917,6 @@ void MainWindow::RxData()
                         HV_Discharge_Timer =distime;
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        cmd = TxString;
                         rxLen = TxString.length();
                         sendSer(0);
                         break;
@@ -974,7 +958,6 @@ void MainWindow::RxData()
                     status = Sweep_set;
                     timeout = ADC_READ_TIMEOUT;
                     rxLen = 0;
-                    cmd = "";
                 }
                 else
                 {
@@ -993,7 +976,6 @@ void MainWindow::RxData()
                         ui->statusBar->showMessage("Sweep complete");
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        cmd = TxString;
                         rxLen = TxString.length();
                         sendSer(0);
                     }
@@ -1006,7 +988,7 @@ void MainWindow::RxData()
             if (HV_Discharge_Timer>0) HV_Discharge_Timer--;
             if (HV_Discharge_Timer == (distime-1))
             {
-                cmd = TxString = "300000000000000000";
+                TxString = "300000000000000000";
                 rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -430,7 +430,6 @@ void MainWindow::readData()
         while (portInUse->bytesAvailable())
         {
             rxChar = portInUse->read(1).at(0);
-            RxString.append(rxChar);
             SendCommand(NULL, false, rxChar);
         }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -617,24 +617,21 @@ void MainWindow::RxData()
     }
 
     // ---------------------------------------------------
-    if (sendADC == true)
+    // Deal with user requests, communications must be idle
+    if (RxCode == RXIDLE || RxCode == RXSUCCESS)
     {
-        qDebug() << "RxData: Action sendADC";
-        heat = 0;
-        SendADCCommand(&CmdRsp);
-        status = wait_adc;
-        sendADC = false;
-        return;
-    }
-
-    if (sendPing == true)
-    {
-        qDebug() << "RxData: Action sendPing";
-        heat = 0;
-        SendEndMeasurementCommand(&CmdRsp);
-        status = WaitPing;
-        sendPing = false;
-        return;
+        if (sendADC == true)
+        {
+            qDebug() << "RxData: Action sendADC";
+            status = read_adc;
+            sendADC = false;
+        }
+        else if (sendPing == true)
+        {
+            qDebug() << "RxData: Action sendPing";
+            status = send_ping;
+            sendPing = false;
+        }
     }
 
     // ---------------------------------------------------
@@ -644,6 +641,20 @@ void MainWindow::RxData()
 
     switch (status)
     {
+        case send_ping:
+        {
+            heat = 0;
+            SendEndMeasurementCommand(&CmdRsp);
+            status = WaitPing;
+            break;
+        }
+        case read_adc:
+        {
+            heat = 0;
+            SendADCCommand(&CmdRsp);
+            status = wait_adc;
+            break;
+        }
         case Idle:
         {
             time = 0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -578,6 +578,7 @@ void MainWindow::RxData()
     static int Ir[]={8,1,2,3,4,5,6,7};
     static QByteArray response;
     static int distime;
+    int RxCode;
 
     // ---------------------------------------------------
     // Sanity check that the port is still OK
@@ -588,6 +589,30 @@ void MainWindow::RxData()
         return;
     }
 
+    // ---------------------------------------------------
+    // Check for the uTracer response
+    RxCode = RxPkt(&CmdRsp, &response);
+    // Check for timeout
+    if (RxCode == RXTIMEOUT)
+    {
+        qDebug() << "RxData: Action RxCode RXTIMEOUT";
+        ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
+        status = Idle;
+        StopTheMachine();
+        return;
+    }
+
+    // Check for invalid response
+    if (RxCode == RXINVALID)
+    {
+        qDebug() << "RxData: Action RxCode RXINVALID";
+        ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
+        status = Idle;
+        StopTheMachine();
+        return;
+    }
+
+    // ---------------------------------------------------
     if (sendADC == true)
     {
         qDebug() << "RxData: Action sendADC";
@@ -605,30 +630,6 @@ void MainWindow::RxData()
         SendEndMeasurementCommand(&CmdRsp);
         status = WaitPing;
         sendPing = false;
-        return;
-    }
-
-    // ---------------------------------------------------
-    // Check for the uTracer response
-    int RxCode = RxPkt(&CmdRsp, &response);
-    // Check for timeout
-    if (RxCode == RXTIMEOUT)
-    {
-        qDebug() << "RxData: Action RxCode RXTIMEOUT";
-        ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
-        SendEndMeasurementCommand(&CmdRsp);
-        response.clear();
-        status = Idle;
-        return;
-    }
-
-    // Check for invalid rsponse
-    if (RxCode == RXINVALID)
-    {
-        qDebug() << "RxData: Action RxCode RXINVALID";
-        ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
-        response.clear();
-        status = Idle;
         return;
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -197,22 +197,25 @@ void MainWindow::SerialPortDiscovery()
 void MainWindow::OpenComPort(const QString *portName, bool updateCalFile)
 {
     qDebug() <<"MainWindow::OpenComPort";
-    //Close open port
-    if (portInUse->isOpen()) {
+
+    // Close open port
+    if (portInUse->isOpen())
+    {
         disconnect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         qDebug() << "Closing Port:" << portInUse->portName();
         portInUse->close();
     }
-    //Open requested port
+
+    // Open requested port
     comport = *portName;
     portInUse->setPortName(comport);
-    qDebug() << "MainWindow::OpenComPort"  << portInUse->portName();
+    qDebug() << "MainWindow::OpenComPort" << portInUse->portName();
     QString msg;
-    if ( portInUse->open(QIODevice::ReadWrite))
+    if (portInUse->open(QIODevice::ReadWrite))
     {
         connect(portInUse, SIGNAL(readyRead()), this, SLOT(readData()));
         msg = QString("Port %1 opened").arg(comport);
-        if(updateCalFile)
+        if (updateCalFile)
             SaveCalFile(); //Update cal file with new port info
     }
     else
@@ -221,8 +224,9 @@ void MainWindow::OpenComPort(const QString *portName, bool updateCalFile)
     }
     ui->statusBar->showMessage(msg);
 
-    //Start RxData Timer
-    if (timer==NULL) {
+    // Start RxData Timer
+    if (timer==NULL)
+    {
         timer = new QTimer(this);
         connect(timer, SIGNAL(timeout()), this, SLOT(RxData()));
         ui->statusBar->showMessage("Starting up...");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1349,68 +1349,68 @@ int MainWindow::GetVf(float v)
 // Calibration File Management
 bool MainWindow::ReadCalibration()
 {
-    //Check to see if the cal file exists
-    QFile datafile(calFileName);
-    qDebug() << "Default calibration filename:" << calFileName;
-    if (! datafile.exists())
+    // Start with the default calibration values
+    // Default to the first serial port (if present)
+    QList<QSerialPortInfo> serPortInfo = QSerialPortInfo::availablePorts();
+    if (serPortInfo.count() > 0 && !serPortInfo.at(0).portName().isEmpty())
     {
-        //It doesn't exist so set up default values and create a file
-        if (!datafile.open(QIODevice::WriteOnly | QIODevice::Text))
-        {
-            qDebug() << "ERROR: failed to open for writing:" << calFileName;
-            return(false);
-        }
-        QTextStream calFile(&datafile);
-        calFile << "COM=COM1\n";
-        calFile << "Va=1.0\n";
-        calFile << "Vs=1.0\n";
-        calFile << "Ia=1.0\n";
-        calFile << "Is=1.0\n";
-        calFile << "Vsu=1.0\n";
-        calFile << "Vg1=1.0\n";
-        calFile << "Vg4=1.0\n";
-        calFile << "Vg40=1.0\n";
-        calFile << "Vg40=1.0\n";
-        calFile << "Vn=1.0\n";
-        calFile << "RaVal=6800\n";
-        calFile << "VaMax=300\n";
-        calFile << "IaMax=200\n";
-        calFile << "IsMax=200\n";
-        calFile << "VgMax=50\n";
-        calFile << ";Define pen number,color RGB, and width\n";
-        int r,g,b,w,h,s,v;
-        for(int i=0; i<16; i++) {
-            h = (360*(i % 16))/16;
-            s = 200;
-            v = 240-100*(i/16);
-            r = QColor::fromHsv(h,s,v,255).red() ;
-            g = QColor::fromHsv(h,s,v,255).green() ;
-            b = QColor::fromHsv(h,s,v,255).blue() ;
-            calFile << "PenNRGBWS="<< i << "," << r << "," << g << "," << b << "," << 2 << "\n";
-        }
-        calFile.flush();
-        datafile.close();
-        qDebug() << "ReadCalibration: Created new cal file" << calFileName;
+        // Use the first available serial port
+        comport = serPortInfo.at(0).portName();
     }
-    //Initialize a Pen List-
-    int r,g,b,w,h,s,v;
+    else
+    {
+        // Otherwise indicate no serial port
+        comport = "none";
+    }
+
+    // These are the calibrations values including comport.
+    calData.VaVal = 1.0;
+    calData.VsVal = 1.0;
+    calData.IaVal = 1.0;
+    calData.IsVal = 1.0;
+    calData.VsuVal = 1.0;
+    calData.Vg1Val = 1.0;
+    calData.Vg4Val = 1.0;
+    calData.Vg40Val = 1.0;
+    calData.VnVal = 1.0;
+    calData.RaVal = 6800;
+    calData.VaMax = 300;
+    calData.IaMax = 200;
+    calData.IsMax = 200;
+    calData.VgMax = 50;
+
+    // Initialise the Pen List colours
+    int r, g, b, h, s, v;
     QPen grPen;
-    for(int i=0; i<16; i++) {
-        h = (360*(i % 16))/16;
+    for (int i = 0; i < 16; i++)
+    {
+        h = (360 * (i % 16)) / 16;
         s = 200;
-        v = 240-100*(i/16);
-        r = QColor::fromHsv(h,s,v,255).red() ;
-        g = QColor::fromHsv(h,s,v,255).green() ;
-        b = QColor::fromHsv(h,s,v,255).blue() ;
-        grPen.setColor(QColor::fromRgb(r,g,b));
+        v = 240 - 100 * (i / 16);
+        r = QColor::fromHsv(h, s, v, 255).red();
+        g = QColor::fromHsv(h, s, v, 255).green();
+        b = QColor::fromHsv(h, s, v, 255).blue();
+        grPen.setColor(QColor::fromRgb(r, g, b));
         grPen.setWidthF(2);
         penList->append(grPen);
     }
-    //Create a black pen to fill unused entries
+
+    // Check to see if the calibration file exists
+    QFile datafile(calFileName);
+    qDebug() << "Default calibration filename:" << calFileName;
+    if (!datafile.exists())
+    {
+        // Create a default calibration file
+        if (!SaveCalFile())
+            return(false);
+    }
+
+    // Create a black pen to fill unused entries
     QPen black;
     black.setColor(QColor::fromRgb(0,0,0,255));
     black.setWidthF(2);
-    //Open the cal.txt file
+
+    // Read the calibration file which will replace the default settings in memory
     if (!datafile.open(QIODevice::ReadOnly | QIODevice::Text))
     {
         qDebug() << "ERROR: failed to open for reading:" << calFileName;
@@ -1468,14 +1468,14 @@ bool MainWindow::ReadCalibration()
     return(true);
 }
 
-void MainWindow::SaveCalFile()
+bool MainWindow::SaveCalFile()
 {
     qDebug () << "SaveCalFile...";
+    bool ret = false;
     QFile datafile(calFileName);
     if (datafile.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QTextStream calFile(&datafile);
-        if (portInUse!=NULL) calFile << "COM=" << portInUse->portName() << "\n";
-        else calFile << "COM=COM1\n";
+        calFile << "COM=" << comport << "\n";
         calFile << "Va=" << calData.VaVal << "\n";
         calFile << "Vs=" << calData.VsVal << "\n";
         calFile << "Ia=" << calData.IaVal << "\n";
@@ -1502,8 +1502,11 @@ void MainWindow::SaveCalFile()
         }
         calFile.flush();
         datafile.close();
+        ret = true;
         //qDebug() << "SaveCalFile: ...updated cal file";
     } else qDebug() << "Save Cal file failed";
+
+    return(ret);
 }
 
 //------------------------------------------------------

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -94,7 +94,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
     timer = NULL;
     status = Idle;
-    startSweep = 0;
     stop = false;
     doStop = false;
     doStart = false;
@@ -583,6 +582,7 @@ void MainWindow::RxData()
     static QByteArray response;
     static int distime;
     RxStatus_t RxCode;
+    static bool repeatTest = false;
 
     // ---------------------------------------------------
     // Sanity check that the port is still OK
@@ -641,11 +641,46 @@ void MainWindow::RxData()
         else if (doStart == true)
         {
             qDebug() << "RxData: Action doStart";
-            if (SetUpSweepParams())
-            {
-                startSweep += 1;
-            }
             doStart = false;
+            if (!SetUpSweepParams()) return;
+
+            switch (status)
+            {
+                case Idle:
+                {
+                    qDebug() << "RxData: Start from Idle";
+                    repeatTest = false;
+                    status = start_sweep_heater;
+                    break;
+                }
+                case Heating:
+                {
+                    qDebug() << "RxData: Jump to max heating";
+                    heat = HEAT_CNT_MAX;
+                    break;
+                }
+                case heat_done:
+                {
+                    qDebug() << "RxData: Start the sweep test now";
+                    if (dataStore->length() > 0) dataStore->clear();
+                    CreateTestVectors();
+                    curve = 0;
+                    status = Sweep_set;
+                    break;
+                }
+                case Sweep_adc:
+                case Sweep_set:
+                {
+                    qDebug() << "RxData: Repeat the test run";
+                    repeatTest = true;
+                    break;
+                }
+                default:
+                {
+                    qDebug() << "ERROR: RxData: Cannot start from state:" << status_name[status];
+                    break;
+                }
+            }
         }
     }
 
@@ -670,43 +705,31 @@ void MainWindow::RxData()
             status = wait_adc;
             break;
         }
-        case Idle:
+        case start_sweep_heater:
         {
             time = 0;
 
-            if (startSweep > 0)
-            {
-                startSweep -= 1;
-                StoreData(false); //Init data store
-                VsStep = 0;
-                VgStep = 0;
-                VaStep = 0;
-                curve = 0;
+            StoreData(false); // Init data store
+            VsStep = 0;
+            VgStep = 0;
+            VaStep = 0;
+            curve = 0;
 
-                if (heat != HEAT_CNT_MAX)
-                {
-                    ui->statusBar->showMessage("Heating setup");
-                    status = Heating_wait00;
-                    heat = 0;
-                    ui->HeaterProg->setValue(1);
-                }
-                else
-                {
-                    ui->statusBar->showMessage("Sweep setup");
-                    status = Sweep_set;
-                    delay=options.Delay;
-                }
+            ui->statusBar->showMessage("Heating setup");
+            heat = 0;
+            ui->HeaterProg->setValue(1);
+            ui->CaptureProg->setValue(1);
 
-                ui->CaptureProg->setValue(1);
+            SendStartMeasurementCommand(&CmdRsp, lim[options.Ilimit], avg[options.AvgNum],
+                                        Ir[options.IsRange], Ir[options.IaRange]);
 
-                SendStartMeasurementCommand(&CmdRsp, lim[options.Ilimit], avg[options.AvgNum],
-                                            Ir[options.IsRange], Ir[options.IaRange]);
-            }
-            else
-            {
-                // All operations completed so stop
-                StopTheMachine();
-            }
+            status = Heating_wait00;
+            break;
+        }
+        case Idle:
+        {
+            // All operations completed so stop
+            StopTheMachine();
             break;
         }
         case WaitPing:
@@ -768,11 +791,6 @@ void MainWindow::RxData()
             {
                 if (heat <= HEAT_CNT_MAX)
                 {
-                    if (startSweep > 0)
-                    {
-                        startSweep -= 1;
-                        heat = HEAT_CNT_MAX;
-                    }
                     ui->HeaterProg->setValue((100 * heat) / HEAT_CNT_MAX);
                     VfADC = GetVf((float)heat);
                     if (VfADC > 1023) VfADC = 1023;
@@ -801,9 +819,8 @@ void MainWindow::RxData()
                 SendFilamentCommand(&CmdRsp, 0);
                 ui->CaptureProg->setValue(0);
             }
-            else if (startSweep > 0 || time / 1000 == HEAT_WAIT_SECS)
+            else if (time / 1000 == HEAT_WAIT_SECS)
             {
-                startSweep = 0;
                 if (dataStore->length() > 0) dataStore->clear();
                 CreateTestVectors();
                 curve = 0;
@@ -979,8 +996,9 @@ void MainWindow::RxData()
                 }
                 else
                 {
-                    if (startSweep > 0) //skip re-heating
+                    if (repeatTest) //skip re-heating
                     {
+                        repeatTest = false;
                         status = heat_done;
                         ui->statusBar->showMessage("Sweep complete");
                         ui->CaptureProg->setValue(100);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -94,7 +94,6 @@ MainWindow::MainWindow(QWidget *parent) :
     status=Idle;
     startSweep=0;
     stop=false;
-    timeout=PING_TIMEOUT;
     timer=NULL;
     newMessage=false;
     sendADC=false;
@@ -440,11 +439,11 @@ int MainWindow::RxPkt(QByteArray *response)
     // Temporary
     CommandResponse_t *pSendCmdRsp = &CmdRsp;
 
-    if (timeout)
+    if (pSendCmdRsp->timeout)
     {
-        timeout--;
+        pSendCmdRsp->timeout--;
 
-        if (timeout == 0)
+        if (pSendCmdRsp->timeout == 0)
         {
             qDebug() << "RxPkt: TIMEOUT - try reading for missing RX";
             readData();
@@ -464,7 +463,7 @@ int MainWindow::RxPkt(QByteArray *response)
         pSendCmdRsp->txState = TxIdle;
         pSendCmdRsp->rxState = RxIdle;
 
-        timeout = 0;
+        pSendCmdRsp->timeout = 0;
 
         // For the debug window
         TxString = pSendCmdRsp->Command;
@@ -497,7 +496,7 @@ void MainWindow::SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uin
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -513,7 +512,7 @@ void MainWindow::SendGetMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint1
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 38;
-    timeout = ADC_READ_TIMEOUT;
+    pSendCmdRsp->timeout = ADC_READ_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -529,7 +528,7 @@ void MainWindow::SendHoldMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = ADC_READ_TIMEOUT + delay;
+    pSendCmdRsp->timeout = ADC_READ_TIMEOUT + delay;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -538,7 +537,7 @@ void MainWindow::SendEndMeasurementCommand(CommandResponse_t *pSendCmdRsp)
     qDebug() << "Send End Measurement command:";
     pSendCmdRsp->Command = "300000000000000000";
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -552,7 +551,7 @@ void MainWindow::SendFilamentCommand(CommandResponse_t *pSendCmdRsp, uint16_t fi
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -561,7 +560,7 @@ void MainWindow::SendADCCommand(CommandResponse_t *pSendCmdRsp)
     qDebug() << "Send ADC command:";
     pSendCmdRsp->Command = "500000000000000000";
     pSendCmdRsp->ExpectedRspLen = 38;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -945,7 +944,6 @@ void MainWindow::RxData()
                     ui->statusBar->showMessage(msg);
                     delay = options.Delay;
                     status = Sweep_set;
-                    timeout = ADC_READ_TIMEOUT;
                 }
                 else
                 {
@@ -992,7 +990,6 @@ void MainWindow::RxData()
             }
             else
             {
-                timeout = PING_TIMEOUT;
                 QString msg = QString("Countdown for HV to discharge: %1").arg(HV_Discharge_Timer);
                 ui->statusBar->showMessage(msg);
             }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -150,6 +150,7 @@ public:
     void DataSaveDialog_clicked(const QString &);
     bool OpenComPort(const QString *, bool updateCalFile);
     bool CloseComPort();
+    void RequestOperation(Operation_t ReqOperation);
 
 public slots:
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -270,6 +270,38 @@ private:
 
     QSerialPort *portInUse;
 
+    enum RxState_t
+    {
+        RxIdle,
+        RxEchoed,
+        RxEchoError,
+        RxResponse,
+        RxComplete
+    };
+
+    enum TxState_t
+    {
+        TxIdle,
+        TxLoaded,
+        TxSending,
+        TxRxing,
+        TxComplete
+    };
+
+    struct CommandResponse_t
+    {
+        QByteArray Command;
+        int txPos;
+        TxState_t txState;
+        int ExpectedRspLen;
+        QByteArray Response;
+        int rxPos;
+        RxState_t rxState;
+        int timeout;
+    };
+
+    CommandResponse_t CmdRsp;
+
     // Function protoypes
     void PenUpdate();
     void updateLcdsWithModel();
@@ -292,7 +324,7 @@ private:
     bool SaveTubeDataFile();
     void StartUpMachine();
     void StopTheMachine();
-    int RxPkt(QByteArray *pResponse);
+    int RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response);
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
     void SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint8_t limits, uint8_t averaging,
                                      uint8_t screenGain, uint8_t anodeGain);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -139,9 +139,7 @@ public:
     float VgNow;
     float VfNow;
     //QextSerialPort * portInUse;
-    //QList<QextPortInfo> serPortInfo;
     QSerialPort * portInUse;
-    QList<QSerialPortInfo> serPortInfo;
     QString comport;
     void OpenComPort(const QString *, bool updateCalFile);
     QString uTmaxDir;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -279,6 +279,8 @@ private:
     void DoPlot(plotInfo_t *  );
     void RePlot(QList<results_t> * );
     bool SaveTubeDataFile();
+    void StartUpMachine();
+    void StopTheMachine();
 
     QList<QPen> * penList;
     int RxPkt(int len, QByteArray * pCmd, QByteArray * pResponse);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -204,7 +204,6 @@ private:
     QTimer *timer;
     bool ok;
     bool newMessage;
-    QByteArray RxString;
     float Vdi;
     float power;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -61,6 +61,7 @@ public:
     QString calFileName;
     bool ReadCalibration();
     bool ReadDataFile();
+    void SerialPortDiscovery();
     ~MainWindow();
 
     void SaveCalFile();
@@ -143,6 +144,8 @@ public:
     QList<QSerialPortInfo> serPortInfo;
     QString comport;
     void OpenComPort(const QString *);
+    QString uTmaxDir;
+
 
 
 public slots:
@@ -185,7 +188,6 @@ private:
     Ui::MainWindow *ui;
     void PenUpdate();
     void updateLcdsWithModel();
-    void SerialPortDiscovery();
     void updateSweepGreying();
     void updateTubeGreying();
     void CreateTestVectors();
@@ -196,7 +198,6 @@ private:
                     Sweep_set, Sweep_adc, Idle, wait_adc,
                     hold_ack, hold, heat_done,HeatOff};
     Status_t status;
-    QString uTmaxDir;
     int startSweep;
     int VsStep;
     int VgStep;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -199,7 +199,6 @@ private:
     int curve;
     int heat;
     bool stop;
-    int timeout;
     QTimer *timer;
     bool ok;
     bool newMessage;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -283,7 +283,6 @@ private:
     int GetVs(float);
     int GetVg(float);
     int GetVf(float);
-    void sendSer(int ExpectedRspLen);
     void StoreData(bool);
     void SetUpPlot();
     bool SetUpSweepParams();
@@ -296,5 +295,14 @@ private:
     void StopTheMachine();
     int RxPkt(QByteArray *pResponse);
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
+    void SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint8_t limits, uint8_t averaging,
+                                     uint8_t screenGain, uint8_t anodeGain);
+    void SendGetMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint16_t anodeV, uint16_t screenV,
+                                   uint16_t gridV, uint16_t filamentV);
+    void SendHoldMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint16_t anodeV, uint16_t screenV,
+                                    uint16_t gridV, uint16_t filamentV, int delay);
+    void SendEndMeasurementCommand(CommandResponse_t *pSendCmdRsp);
+    void SendFilamentCommand(CommandResponse_t *pSendCmdRsp, uint16_t filament);
+    void SendADCCommand(CommandResponse_t *pSendCmdRsp);
 };
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -143,7 +143,7 @@ public:
     QSerialPort * portInUse;
     QList<QSerialPortInfo> serPortInfo;
     QString comport;
-    void OpenComPort(const QString *);
+    void OpenComPort(const QString *, bool updateCalFile);
     QString uTmaxDir;
 
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -138,12 +138,10 @@ public:
     float VsNow;
     float VgNow;
     float VfNow;
-    //QextSerialPort * portInUse;
-    QSerialPort * portInUse;
     QString comport;
     bool OpenComPort(const QString *, bool updateCalFile);
     QString uTmaxDir;
-
+    bool CloseComPort();
 
 
 public slots:
@@ -290,6 +288,7 @@ private:
     QList<PlotTabWidget*> plotTabs;
     bool ignoreIndexChange;
 
+    QSerialPort *portInUse;
 
 };
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -285,7 +285,7 @@ private:
     int GetVs(float);
     int GetVg(float);
     int GetVf(float);
-    void sendSer();
+    void sendSer(int ExpectedRspLen);
     void StoreData(bool);
     void SetUpPlot();
     bool SetUpSweepParams();
@@ -297,5 +297,6 @@ private:
     void StartUpMachine();
     void StopTheMachine();
     int RxPkt(int len, QByteArray *pCmd, QByteArray *pResponse);
+    void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
 };
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -189,11 +189,14 @@ private:
     void CreateTestVectors();
     void ClearLCDs();
 
-
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
-                    hold_ack, hold, heat_done,HeatOff};
+                    hold_ack, hold, heat_done, HeatOff};
     Status_t status;
+    QString status_name[HeatOff + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
+                                        "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
+                                        "hold_ack", "hold", "heat_done", "HeatOff"};
+
     int startSweep;
     int VsStep;
     int VgStep;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -200,7 +200,6 @@ private:
     bool doStart;
     QTimer *timer;
     bool ok;
-    bool newMessage;
     float Vdi;
     float power;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -4,10 +4,7 @@
 #define TIMER_SET 500
 #define ADC_READ_TIMEOUT (30000/TIMER_SET)
 #define PING_TIMEOUT (5000/TIMER_SET)
-#define RXSUCCESS 1
-#define RXTIMEOUT -1
-#define RXCONTINUE 0
-#define RXINVALID -2
+
 #define HEAT_CNT_MAX 20
 #define HEAT_WAIT_SECS 60
 
@@ -302,6 +299,15 @@ private:
 
     CommandResponse_t CmdRsp;
 
+    enum RxStatus_t
+    {
+        RXSUCCESS,
+        RXCONTINUE,
+        RXIDLE,
+        RXTIMEOUT,
+        RXINVALID
+    };
+
     // Function protoypes
     void PenUpdate();
     void updateLcdsWithModel();
@@ -324,7 +330,7 @@ private:
     bool SaveTubeDataFile();
     void StartUpMachine();
     void StopTheMachine();
-    int RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response);
+    void RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response, RxStatus_t *pRxStatus);
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
     void SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint8_t limits, uint8_t averaging,
                                      uint8_t screenGain, uint8_t anodeGain);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -59,7 +59,7 @@ public:
     calData_t calData;
     QString dataFileName;
     QString calFileName;
-    void ReadCalibration();
+    bool ReadCalibration();
     bool ReadDataFile();
     ~MainWindow();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -196,6 +196,8 @@ private:
     int curve;
     int heat;
     bool stop;
+    bool doStop;
+    bool doStart;
     QTimer *timer;
     bool ok;
     bool newMessage;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -64,7 +64,7 @@ public:
     void SerialPortDiscovery();
     ~MainWindow();
 
-    void SaveCalFile();
+    bool SaveCalFile();
     void GetReal();
     void DataSaveDialog_clicked(const QString &);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -13,8 +13,6 @@
 
 
 #include <QMainWindow>
-//#include "../3rdparty/qextserialport-1.2rc/src/qextserialport.h"
-//#include "../3rdparty/qextserialport-1.2rc/src/qextserialenumerator.h"
 #include <QQueue>
 #include <QTimer>
 #include <QFile>
@@ -29,8 +27,9 @@
 #include <QtSerialPort/QSerialPortInfo>
 
 
-namespace Ui {
-class MainWindow;
+namespace Ui
+{
+    class MainWindow;
 }
 
 class MainWindow : public QMainWindow
@@ -38,7 +37,9 @@ class MainWindow : public QMainWindow
     Q_OBJECT
     
 public:
+    // Type and variable declarations
     explicit MainWindow(QWidget *parent = 0);
+
     struct calData_t
     {
         float VaVal;
@@ -55,18 +56,11 @@ public:
         float IaMax=200;
         float IsMax=200;
         float VgMax=-57;
-    } ;
+    };
+
     calData_t calData;
     QString dataFileName;
     QString calFileName;
-    bool ReadCalibration();
-    bool ReadDataFile();
-    void SerialPortDiscovery();
-    ~MainWindow();
-
-    bool SaveCalFile();
-    void GetReal();
-    void DataSaveDialog_clicked(const QString &);
 
     struct adc_data_t
     {
@@ -81,6 +75,7 @@ public:
         int Gain_a;
         int Gain_s;
     };
+
     // This holds the ADC data from uTracer
     adc_data_t adc_data;
 
@@ -103,9 +98,12 @@ public:
         float Gain_a;
         float Gain_s;
     };
+
     adc_scale_t adc_scale;  //the ADC scale factors
     adc_scale_t adc_real;   //the real version of the ADC readings
-    struct options_t {
+
+    struct options_t
+{
         int IaRange;
         int IsRange;
         int Delay;
@@ -114,6 +112,7 @@ public:
         bool AbortOnLimit;
         float VgScale;
     };
+
     options_t options;
 
     QByteArray TxString;
@@ -139,16 +138,20 @@ public:
     float VgNow;
     float VfNow;
     QString comport;
-    bool OpenComPort(const QString *, bool updateCalFile);
     QString uTmaxDir;
+
+    // Function protoypes
+    ~MainWindow();
+    bool ReadCalibration();
+    bool ReadDataFile();
+    void SerialPortDiscovery();
+    bool SaveCalFile();
+    void GetReal();
+    void DataSaveDialog_clicked(const QString &);
+    bool OpenComPort(const QString *, bool updateCalFile);
     bool CloseComPort();
 
-
 public slots:
-    //void onDeviceDiscovered(const QextPortInfo & );
-    //void onDeviceRemoved(const QextPortInfo & );
-    //TODO Update plot when this happens:
-    //void ErrorWeightClicked();
 
 
 private slots:
@@ -166,10 +169,7 @@ private slots:
     void on_Stop_clicked();
     void on_TubeType_currentIndexChanged(int index);
     void on_actionSave_Spice_Model_triggered();
-    //void on_plotDockWidget_dockLocationChanged(const Qt::DockWidgetArea &area);
-    //void on_plotDockWidget_topLevelChanged(bool topLevel);
     void on_actionRead_Data_triggered();
-    //void on_actionPreferences_triggered();
     void on_AutoPath_editingFinished();
     void on_AddType_clicked();
     void on_DeleteType_clicked();
@@ -177,17 +177,11 @@ private slots:
     void on_checkQuickTest_clicked();
     void on_Tabs_currentChanged(int index);
     void on_Tabs_tabCloseRequested(int index);
-
     void on_Browse_clicked();
 
 private:
+    // Type and variable declarations
     Ui::MainWindow *ui;
-    void PenUpdate();
-    void updateLcdsWithModel();
-    void updateSweepGreying();
-    void updateTubeGreying();
-    void CreateTestVectors();
-    void ClearLCDs();
 
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
@@ -206,24 +200,14 @@ private:
     bool stop;
     bool timer_on;
     int timeout;
-    QTimer * timer;
-    void saveADCInfo(QByteArray *);
-    int GetVa(float);
-    int GetVs(float);
-    int GetVg(float);
-    int GetVf(float);
+    QTimer *timer;
     bool ok;
     bool newMessage;
-    void sendSer();
     QByteArray RxString;
-    void StoreData(bool);
-    void SetUpPlot();
-    bool SetUpSweepParams();
     float Vdi;
     float power;
-    void UpdateTitle();
 
-    //test vector store
+    // Test vector store
     struct test_vector_t {
         float Va, Vs, Vg;
     };
@@ -231,7 +215,7 @@ private:
     test_vector_t test_vector;
     QList<test_vector_t> *sweepList;
 
-    //results store
+    // Results store
     results_t results;
     QList<results_t> *dataStore;
     QList<results_t> *refStore;
@@ -273,27 +257,44 @@ private:
         float EmmVg;
         float EmmIa;
     };
+
     tubeData_t tubeData;
     QList<tubeData_t> *tubeDataList;
 
     plotInfo_t plot1;
 
-    void LabelPins(tubeData_t);
-    void DoPlot(plotInfo_t *  );
-    void RePlot(QList<results_t> * );
-    bool SaveTubeDataFile();
-    void StartUpMachine();
-    void StopTheMachine();
-
-    QList<QPen> * penList;
-    int RxPkt(int len, QByteArray * pCmd, QByteArray * pResponse);
+    QList<QPen> *penList;
     QFile logFile;
-    dr_optimize * optimizer;
+    dr_optimize *optimizer;
 
     QList<PlotTabWidget*> plotTabs;
     bool ignoreIndexChange;
 
     QSerialPort *portInUse;
 
+    // Function protoypes
+    void PenUpdate();
+    void updateLcdsWithModel();
+    void updateSweepGreying();
+    void updateTubeGreying();
+    void CreateTestVectors();
+    void ClearLCDs();
+    void saveADCInfo(QByteArray *);
+    int GetVa(float);
+    int GetVs(float);
+    int GetVg(float);
+    int GetVf(float);
+    void sendSer();
+    void StoreData(bool);
+    void SetUpPlot();
+    bool SetUpSweepParams();
+    void UpdateTitle();
+    void LabelPins(tubeData_t);
+    void DoPlot(plotInfo_t *);
+    void RePlot(QList<results_t> *);
+    bool SaveTubeDataFile();
+    void StartUpMachine();
+    void StopTheMachine();
+    int RxPkt(int len, QByteArray *pCmd, QByteArray *pResponse);
 };
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -60,7 +60,7 @@ public:
     QString dataFileName;
     QString calFileName;
     void ReadCalibration();
-    void ReadDataFile();
+    bool ReadDataFile();
     ~MainWindow();
 
     void SaveCalFile();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -183,13 +183,14 @@ private:
 
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
-                    hold_ack, hold, heat_done, HeatOff, read_adc, send_ping};
+                    hold_ack, hold, heat_done, HeatOff, read_adc, send_ping,
+                    start_sweep_heater, max_state};
     Status_t status;
-    QString status_name[send_ping + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
-                                        "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
-                                        "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping"};
+    QString status_name[max_state] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
+                                      "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
+                                      "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping",
+                                      "start_sweep_heater"};
 
-    int startSweep;
     int VsStep;
     int VgStep;
     int VaStep;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -141,7 +141,7 @@ public:
     //QextSerialPort * portInUse;
     QSerialPort * portInUse;
     QString comport;
-    void OpenComPort(const QString *, bool updateCalFile);
+    bool OpenComPort(const QString *, bool updateCalFile);
     QString uTmaxDir;
 
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -184,19 +184,18 @@ private:
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
                     hold_ack, hold, heat_done, HeatOff, read_adc, send_ping,
-                    start_sweep_heater, max_state};
+                    start_sweep_heater, wait_stop, max_state};
     Status_t status;
     QString status_name[max_state] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
                                       "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
                                       "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping",
-                                      "start_sweep_heater"};
+                                      "start_sweep_heater", "wait_stop"};
 
     int VsStep;
     int VgStep;
     int VaStep;
     int curve;
     int heat;
-    bool stop;
     bool doStop;
     bool doStart;
     QTimer *timer;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -199,7 +199,6 @@ private:
     int curve;
     int heat;
     bool stop;
-    bool timer_on;
     int timeout;
     QTimer *timer;
     bool ok;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -296,7 +296,7 @@ private:
     bool SaveTubeDataFile();
     void StartUpMachine();
     void StopTheMachine();
-    int RxPkt(int len, QByteArray *pCmd, QByteArray *pResponse);
+    int RxPkt(QByteArray *pResponse);
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
 };
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -183,11 +183,11 @@ private:
 
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
-                    hold_ack, hold, heat_done, HeatOff};
+                    hold_ack, hold, heat_done, HeatOff, read_adc, send_ping};
     Status_t status;
-    QString status_name[HeatOff + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
+    QString status_name[send_ping + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
                                         "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
-                                        "hold_ack", "hold", "heat_done", "HeatOff"};
+                                        "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping"};
 
     int startSweep;
     int VsStep;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -37,7 +37,7 @@
    </font>
   </property>
   <property name="windowTitle">
-   <string>utMax 1.0e</string>
+   <string>uTmax 2.0-rc1 Dean's version</string>
   </property>
   <property name="windowIcon">
    <iconset>
@@ -2685,7 +2685,7 @@ border-color: #800000;
      <x>0</x>
      <y>0</y>
      <width>651</width>
-     <height>22</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuUtgui">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -2425,6 +2425,11 @@ background-color:rgb(0, 0, 0);
              <height>40</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select tube model in database&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -60,37 +60,4 @@ enum Operation_t
     Start
 };
 
-// Temporarily global
-enum RxState_t
-{
-    RxIdle,
-    RxEchoed,
-    RxEchoError,
-    RxResponse,
-    RxComplete
-};
-
-// Temporarily global
-enum TxState_t
-{
-    TxIdle,
-    TxLoaded,
-    TxSending,
-    TxRxing,
-    TxComplete
-};
-
-// Temporarily global
-struct CommandResponse_t
-{
-    QByteArray Command;
-    int txPos;
-    TxState_t txState;
-    int ExpectedRspLen;
-    QByteArray Response;
-    int rxPos;
-    RxState_t rxState;
-    int timeout;
-};
-
 #endif // TYPEDEFS_H

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -90,6 +90,7 @@ struct CommandResponse_t
     QByteArray Response;
     int rxPos;
     RxState_t rxState;
+    int timeout;
 };
 
 #endif // TYPEDEFS_H

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -60,4 +60,36 @@ enum Operation_t
     Start
 };
 
+// Temporarily global
+enum RxState_t
+{
+    RxIdle,
+    RxEchoed,
+    RxEchoError,
+    RxResponse,
+    RxComplete
+};
+
+// Temporarily global
+enum TxState_t
+{
+    TxIdle,
+    TxLoaded,
+    TxSending,
+    TxRxing,
+    TxComplete
+};
+
+// Temporarily global
+struct CommandResponse_t
+{
+    QByteArray Command;
+    int txPos;
+    TxState_t txState;
+    int ExpectedRspLen;
+    QByteArray Response;
+    int rxPos;
+    RxState_t rxState;
+};
+
 #endif // TYPEDEFS_H

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -33,7 +33,8 @@ struct results_t
     float mu_b;
 };
 
-struct plotInfo_t {
+struct plotInfo_t
+{
     int VaSteps;
     int VsSteps;
     int VgSteps;
@@ -43,14 +44,20 @@ struct plotInfo_t {
     float VsEnd;
     float VgStart;
     float VgEnd;
-    QList<results_t> * dataSet;
+    QList<results_t> *dataSet;
     QString tube;
     QString type;
-    QList<QPen> * penList;
+    QList<QPen> *penList;
     bool penChange;
-
-
 };
 
+enum Operation_t
+{
+    Stop,
+    Probe,
+    Ping,
+    ReadADC,
+    Start
+};
 
 #endif // TYPEDEFS_H


### PR DESCRIPTION
Expand the main state machine to take the user requests into the state machine so that state changes can be managed consistently. The integration is not complete but basically works.

Note that sending a communication to the uTracer has to have timeout handling which has been improved by add a RXIDLE state to indicate no communications are in progress. A RXTIMEOUT will cause the state machine to enter the Idle state.

The "start" and "stop" user requests now transitions the state of the main state machine eliminating a small number of flags.