### PR TITLE
Incorporate the user requests into the main state machine

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -91,13 +91,17 @@ MainWindow::MainWindow(QWidget *parent) :
     options.VgScale=1.0;
     portInUse = NULL;
     penList = new QList<QPen>;
-    status=Idle;
-    startSweep=0;
-    stop=false;
-    timer=NULL;
-    newMessage=false;
-    sendADC=false;
-    sendPing=false;
+
+    timer = NULL;
+    status = Idle;
+    startSweep = 0;
+    stop = false;
+    doStop = false;
+    doStart = false;
+    sendADC = false;
+    sendPing = false;
+    newMessage = false;
+
     VaADC=0;
     VsADC=0;
     VgADC=0;
@@ -253,7 +257,7 @@ void MainWindow::RequestOperation(Operation_t ReqOperation)
         case Stop:
         {
             qDebug() << "RequestOperation: Stop";
-            stop = true;
+            doStop = true;
             StartUpMachine();
             break;
         }
@@ -282,11 +286,8 @@ void MainWindow::RequestOperation(Operation_t ReqOperation)
         case Start:
         {
             qDebug() << "RequestOperation: Start";
-            if (SetUpSweepParams())
-            {
-                startSweep += 1;
-                StartUpMachine();
-            }
+            doStart = true;
+            StartUpMachine();
             break;
         }
         default:
@@ -620,17 +621,32 @@ void MainWindow::RxData()
     // Deal with user requests, communications must be idle
     if (RxCode == RXIDLE || RxCode == RXSUCCESS)
     {
-        if (sendADC == true)
+        if (doStop == true)
         {
-            qDebug() << "RxData: Action sendADC";
-            status = read_adc;
-            sendADC = false;
+            qDebug() << "RxData: Action doStop";
+            stop = true;
+            doStop = false;
         }
         else if (sendPing == true)
         {
             qDebug() << "RxData: Action sendPing";
             status = send_ping;
             sendPing = false;
+        }
+        else if (sendADC == true)
+        {
+            qDebug() << "RxData: Action sendADC";
+            status = read_adc;
+            sendADC = false;
+        }
+        else if (doStart == true)
+        {
+            qDebug() << "RxData: Action doStart";
+            if (SetUpSweepParams())
+            {
+                startSweep += 1;
+            }
+            doStart = false;
         }
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -100,7 +100,6 @@ MainWindow::MainWindow(QWidget *parent) :
     doStart = false;
     sendADC = false;
     sendPing = false;
-    newMessage = false;
 
     VaADC=0;
     VsADC=0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -579,6 +579,15 @@ void MainWindow::RxData()
     static QByteArray response;
     static int distime;
 
+    // ---------------------------------------------------
+    // Sanity check that the port is still OK
+    if (!portInUse || !portInUse->isOpen())
+    {
+        ui->statusBar->showMessage("ERROR: The serial port closed unexpectedly!");
+        StopTheMachine();
+        return;
+    }
+
     if (sendADC == true)
     {
         qDebug() << "RxData: Action sendADC";
@@ -596,14 +605,6 @@ void MainWindow::RxData()
         SendEndMeasurementCommand(&CmdRsp);
         status = WaitPing;
         sendPing = false;
-        return;
-    }
-
-    // ---------------------------------------------------
-    // Sanity check that the port is still OK
-    if (!portInUse || !portInUse->isOpen())
-    {
-        ui->statusBar->showMessage("COM port was closed, exit and restart.");
         return;
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -617,24 +617,21 @@ void MainWindow::RxData()
     }
 
     // ---------------------------------------------------
-    if (sendADC == true)
+    // Deal with user requests, communications must be idle
+    if (RxCode == RXIDLE || RxCode == RXSUCCESS)
     {
-        qDebug() << "RxData: Action sendADC";
-        heat = 0;
-        SendADCCommand(&CmdRsp);
-        status = wait_adc;
-        sendADC = false;
-        return;
-    }
-
-    if (sendPing == true)
-    {
-        qDebug() << "RxData: Action sendPing";
-        heat = 0;
-        SendEndMeasurementCommand(&CmdRsp);
-        status = WaitPing;
-        sendPing = false;
-        return;
+        if (sendADC == true)
+        {
+            qDebug() << "RxData: Action sendADC";
+            status = read_adc;
+            sendADC = false;
+        }
+        else if (sendPing == true)
+        {
+            qDebug() << "RxData: Action sendPing";
+            status = send_ping;
+            sendPing = false;
+        }
     }
 
     // ---------------------------------------------------
@@ -644,6 +641,20 @@ void MainWindow::RxData()
 
     switch (status)
     {
+        case send_ping:
+        {
+            heat = 0;
+            SendEndMeasurementCommand(&CmdRsp);
+            status = WaitPing;
+            break;
+        }
+        case read_adc:
+        {
+            heat = 0;
+            SendADCCommand(&CmdRsp);
+            status = wait_adc;
+            break;
+        }
         case Idle:
         {
             time = 0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -578,6 +578,7 @@ void MainWindow::RxData()
     static int Ir[]={8,1,2,3,4,5,6,7};
     static QByteArray response;
     static int distime;
+    int RxCode;
 
     // ---------------------------------------------------
     // Sanity check that the port is still OK
@@ -588,6 +589,30 @@ void MainWindow::RxData()
         return;
     }
 
+    // ---------------------------------------------------
+    // Check for the uTracer response
+    RxCode = RxPkt(&CmdRsp, &response);
+    // Check for timeout
+    if (RxCode == RXTIMEOUT)
+    {
+        qDebug() << "RxData: Action RxCode RXTIMEOUT";
+        ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
+        status = Idle;
+        StopTheMachine();
+        return;
+    }
+
+    // Check for invalid response
+    if (RxCode == RXINVALID)
+    {
+        qDebug() << "RxData: Action RxCode RXINVALID";
+        ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
+        status = Idle;
+        StopTheMachine();
+        return;
+    }
+
+    // ---------------------------------------------------
     if (sendADC == true)
     {
         qDebug() << "RxData: Action sendADC";
@@ -605,30 +630,6 @@ void MainWindow::RxData()
         SendEndMeasurementCommand(&CmdRsp);
         status = WaitPing;
         sendPing = false;
-        return;
-    }
-
-    // ---------------------------------------------------
-    // Check for the uTracer response
-    int RxCode = RxPkt(&CmdRsp, &response);
-    // Check for timeout
-    if (RxCode == RXTIMEOUT)
-    {
-        qDebug() << "RxData: Action RxCode RXTIMEOUT";
-        ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
-        SendEndMeasurementCommand(&CmdRsp);
-        response.clear();
-        status = Idle;
-        return;
-    }
-
-    // Check for invalid rsponse
-    if (RxCode == RXINVALID)
-    {
-        qDebug() << "RxData: Action RxCode RXINVALID";
-        ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
-        response.clear();
-        status = Idle;
         return;
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -94,7 +94,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
     timer = NULL;
     status = Idle;
-    startSweep = 0;
     stop = false;
     doStop = false;
     doStart = false;
@@ -583,6 +582,7 @@ void MainWindow::RxData()
     static QByteArray response;
     static int distime;
     RxStatus_t RxCode;
+    static bool repeatTest = false;
 
     // ---------------------------------------------------
     // Sanity check that the port is still OK
@@ -641,11 +641,46 @@ void MainWindow::RxData()
         else if (doStart == true)
         {
             qDebug() << "RxData: Action doStart";
-            if (SetUpSweepParams())
-            {
-                startSweep += 1;
-            }
             doStart = false;
+            if (!SetUpSweepParams()) return;
+
+            switch (status)
+            {
+                case Idle:
+                {
+                    qDebug() << "RxData: Start from Idle";
+                    repeatTest = false;
+                    status = start_sweep_heater;
+                    break;
+                }
+                case Heating:
+                {
+                    qDebug() << "RxData: Jump to max heating";
+                    heat = HEAT_CNT_MAX;
+                    break;
+                }
+                case heat_done:
+                {
+                    qDebug() << "RxData: Start the sweep test now";
+                    if (dataStore->length() > 0) dataStore->clear();
+                    CreateTestVectors();
+                    curve = 0;
+                    status = Sweep_set;
+                    break;
+                }
+                case Sweep_adc:
+                case Sweep_set:
+                {
+                    qDebug() << "RxData: Repeat the test run";
+                    repeatTest = true;
+                    break;
+                }
+                default:
+                {
+                    qDebug() << "ERROR: RxData: Cannot start from state:" << status_name[status];
+                    break;
+                }
+            }
         }
     }
 
@@ -670,43 +705,31 @@ void MainWindow::RxData()
             status = wait_adc;
             break;
         }
-        case Idle:
+        case start_sweep_heater:
         {
             time = 0;
 
-            if (startSweep > 0)
-            {
-                startSweep -= 1;
-                StoreData(false); //Init data store
-                VsStep = 0;
-                VgStep = 0;
-                VaStep = 0;
-                curve = 0;
+            StoreData(false); // Init data store
+            VsStep = 0;
+            VgStep = 0;
+            VaStep = 0;
+            curve = 0;
 
-                if (heat != HEAT_CNT_MAX)
-                {
-                    ui->statusBar->showMessage("Heating setup");
-                    status = Heating_wait00;
-                    heat = 0;
-                    ui->HeaterProg->setValue(1);
-                }
-                else
-                {
-                    ui->statusBar->showMessage("Sweep setup");
-                    status = Sweep_set;
-                    delay=options.Delay;
-                }
+            ui->statusBar->showMessage("Heating setup");
+            heat = 0;
+            ui->HeaterProg->setValue(1);
+            ui->CaptureProg->setValue(1);
 
-                ui->CaptureProg->setValue(1);
+            SendStartMeasurementCommand(&CmdRsp, lim[options.Ilimit], avg[options.AvgNum],
+                                        Ir[options.IsRange], Ir[options.IaRange]);
 
-                SendStartMeasurementCommand(&CmdRsp, lim[options.Ilimit], avg[options.AvgNum],
-                                            Ir[options.IsRange], Ir[options.IaRange]);
-            }
-            else
-            {
-                // All operations completed so stop
-                StopTheMachine();
-            }
+            status = Heating_wait00;
+            break;
+        }
+        case Idle:
+        {
+            // All operations completed so stop
+            StopTheMachine();
             break;
         }
         case WaitPing:
@@ -768,11 +791,6 @@ void MainWindow::RxData()
             {
                 if (heat <= HEAT_CNT_MAX)
                 {
-                    if (startSweep > 0)
-                    {
-                        startSweep -= 1;
-                        heat = HEAT_CNT_MAX;
-                    }
                     ui->HeaterProg->setValue((100 * heat) / HEAT_CNT_MAX);
                     VfADC = GetVf((float)heat);
                     if (VfADC > 1023) VfADC = 1023;
@@ -801,9 +819,8 @@ void MainWindow::RxData()
                 SendFilamentCommand(&CmdRsp, 0);
                 ui->CaptureProg->setValue(0);
             }
-            else if (startSweep > 0 || time / 1000 == HEAT_WAIT_SECS)
+            else if (time / 1000 == HEAT_WAIT_SECS)
             {
-                startSweep = 0;
                 if (dataStore->length() > 0) dataStore->clear();
                 CreateTestVectors();
                 curve = 0;
@@ -979,8 +996,9 @@ void MainWindow::RxData()
                 }
                 else
                 {
-                    if (startSweep > 0) //skip re-heating
+                    if (repeatTest) //skip re-heating
                     {
+                        repeatTest = false;
                         status = heat_done;
                         ui->statusBar->showMessage("Sweep complete");
                         ui->CaptureProg->setValue(100);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -200,7 +200,6 @@ private:
     bool doStart;
     QTimer *timer;
     bool ok;
-    bool newMessage;
     float Vdi;
     float power;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -4,10 +4,7 @@
 #define TIMER_SET 500
 #define ADC_READ_TIMEOUT (30000/TIMER_SET)
 #define PING_TIMEOUT (5000/TIMER_SET)
-#define RXSUCCESS 1
-#define RXTIMEOUT -1
-#define RXCONTINUE 0
-#define RXINVALID -2
+
 #define HEAT_CNT_MAX 20
 #define HEAT_WAIT_SECS 60
 
@@ -302,6 +299,15 @@ private:
 
     CommandResponse_t CmdRsp;
 
+    enum RxStatus_t
+    {
+        RXSUCCESS,
+        RXCONTINUE,
+        RXIDLE,
+        RXTIMEOUT,
+        RXINVALID
+    };
+
     // Function protoypes
     void PenUpdate();
     void updateLcdsWithModel();
@@ -324,7 +330,7 @@ private:
     bool SaveTubeDataFile();
     void StartUpMachine();
     void StopTheMachine();
-    int RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response);
+    void RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response, RxStatus_t *pRxStatus);
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
     void SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint8_t limits, uint8_t averaging,
                                      uint8_t screenGain, uint8_t anodeGain);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -196,6 +196,8 @@ private:
     int curve;
     int heat;
     bool stop;
+    bool doStop;
+    bool doStart;
     QTimer *timer;
     bool ok;
     bool newMessage;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -183,13 +183,14 @@ private:
 
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
-                    hold_ack, hold, heat_done, HeatOff, read_adc, send_ping};
+                    hold_ack, hold, heat_done, HeatOff, read_adc, send_ping,
+                    start_sweep_heater, max_state};
     Status_t status;
-    QString status_name[send_ping + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
-                                        "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
-                                        "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping"};
+    QString status_name[max_state] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
+                                      "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
+                                      "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping",
+                                      "start_sweep_heater"};
 
-    int startSweep;
     int VsStep;
     int VgStep;
     int VaStep;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -184,19 +184,18 @@ private:
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
                     hold_ack, hold, heat_done, HeatOff, read_adc, send_ping,
-                    start_sweep_heater, max_state};
+                    start_sweep_heater, wait_stop, max_state};
     Status_t status;
     QString status_name[max_state] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
                                       "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
                                       "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping",
-                                      "start_sweep_heater"};
+                                      "start_sweep_heater", "wait_stop"};
 
     int VsStep;
     int VgStep;
     int VaStep;
     int curve;
     int heat;
-    bool stop;
     bool doStop;
     bool doStart;
     QTimer *timer;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -183,11 +183,11 @@ private:
 
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
-                    hold_ack, hold, heat_done, HeatOff};
+                    hold_ack, hold, heat_done, HeatOff, read_adc, send_ping};
     Status_t status;
-    QString status_name[HeatOff + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
+    QString status_name[send_ping + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
                                         "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
-                                        "hold_ack", "hold", "heat_done", "HeatOff"};
+                                        "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping"};
 
     int startSweep;
     int VsStep;


### PR DESCRIPTION
Expand the main state machine to take the user requests into the state machine so that state changes can be managed consistently. The integration is not complete but basically works.

Note that sending a communication to the uTracer has to have timeout handling which has been improved by add a RXIDLE state to indicate no communications are in progress. A RXTIMEOUT will cause the state machine to enter the Idle state.

The "start" and "stop" user requests now transitions the state of the main state machine eliminating a small number of flags.