### PR TITLE
Code improvements to do_stop, printing RxStatus and detect TX not being complete

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -327,6 +327,11 @@ void MainWindow::SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxCha
 
     if (txLoad)
     {
+        if (pSendCmdRsp) {
+            if (pSendCmdRsp->txState != TxIdle)
+                qDebug() << "ERROR: SendCommand: Attempting to send new message before previous message completed!" \
+                         << pSendCmdRsp->txState;
+        }
         pSendCmdRsp = pCmdRsp;
         pSendCmdRsp->txState = TxLoaded;
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -641,8 +641,8 @@ void MainWindow::RxData()
                     ui->HeaterProg->setValue(0);
                     ui->statusBar->showMessage("Heater off");
                     SendFilamentCommand(&CmdRsp, 0);
-                    status = wait_stop;
-                    break;
+                    status = HeatOff;
+                    return;
                 }
                 case Sweep_set:
                 case Sweep_adc:
@@ -655,8 +655,8 @@ void MainWindow::RxData()
                     ui->statusBar->showMessage("Abort:Heater off");
                     SendFilamentCommand(&CmdRsp, 0);
                     ui->CaptureProg->setValue(0);
-                    status = wait_stop;
-                    break;
+                    status = HeatOff;
+                    return;
                 }
                 default:
                 {
@@ -774,14 +774,6 @@ void MainWindow::RxData()
                                         Ir[options.IsRange], Ir[options.IaRange]);
 
             status = Heating_wait00;
-            break;
-        }
-        case wait_stop:
-        {
-            if (RxCode == RXSUCCESS)
-            {
-                status = HeatOff;
-            }
             break;
         }
         case Idle:
@@ -1032,7 +1024,7 @@ void MainWindow::RxData()
         }
         case HeatOff:
         {
-            if (RxCode != RXIDLE && RxCode != RXSUCCESS) break;
+            if (RxCode != RXSUCCESS) break;
 
             if (timeIt)
             {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -627,7 +627,6 @@ void MainWindow::RxData()
         if (doStop == true)
         {
             qDebug() << "RxData: Action doStop";
-            doStop = false;
 
             switch (status)
             {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -451,7 +451,6 @@ void MainWindow::RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response, RxS
     }
     else
     {
-        qDebug() << "RxPkt: RXIDLE";
         *pRxStatus = RXIDLE;
     }
 
@@ -484,6 +483,8 @@ void MainWindow::RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response, RxS
         pSendCmdRsp->txState = TxIdle;
         pSendCmdRsp->rxState = RxIdle;
     }
+
+    qDebug() << "RxPkt: RxStatus is:" << RxStatusName[*pRxStatus];
 }
 
 void MainWindow::SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint8_t limits, uint8_t averaging,

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -314,8 +314,12 @@ private:
         RXCONTINUE,
         RXIDLE,
         RXTIMEOUT,
-        RXINVALID
+        RXINVALID,
+        RXMAX
     };
+
+    QString RxStatusName[RXMAX] = {"RXSUCCESS", "RXCONTINUE", "RXIDLE",
+                                   "RXTIMEOUT", "RXINVALID"};
 
     // Function protoypes
     void PenUpdate();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -186,12 +186,12 @@ private:
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
                     hold_ack, hold, heat_done, HeatOff, read_adc, send_ping,
-                    start_sweep_heater, wait_stop, Discharge, max_state};
+                    start_sweep_heater, Discharge, max_state};
     Status_t status;
     QString status_name[max_state] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
                                       "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
                                       "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping",
-                                      "start_sweep_heater", "wait_stop", "Discharge"};
+                                      "start_sweep_heater", "Discharge"};
 
     struct interrupted_t
     {


### PR DESCRIPTION
Remove the unnecessary state "wait_stop".

Add a bug fix to not clear the do_stop state.

Indicate the RxStatus to make it easier to see the status changes.

Add a test to detect whether the TX has completed before the next TX message starts.