### PR TITLE
main: Add workaround for native qDebug not working

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,38 @@
 #include <QtWidgets/QApplication>
 #include "mainwindow.h"
 
+// Workaround for native qDebug() output not working
+void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    QByteArray localMsg = msg.toLocal8Bit();
+
+	// Reduce logging output by only using data that contains line numbers
+    if (!context.line) return;
+
+    switch (type) {
+    case QtDebugMsg:
+//        fprintf(stderr, "Debug: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        fprintf(stderr, "Debug: %s (%s:%u)\n", localMsg.constData(), context.file, context.line);
+        break;
+    case QtInfoMsg:
+        fprintf(stderr, "Info: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        break;
+    case QtWarningMsg:
+        fprintf(stderr, "Warning: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        break;
+    case QtCriticalMsg:
+        fprintf(stderr, "Critical: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        break;
+    case QtFatalMsg:
+        fprintf(stderr, "Fatal: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        abort();
+    }
+}
+
 int main(int argc, char *argv[])
 {
+    qInstallMessageHandler(myMessageOutput);
+
     QApplication a(argc, argv);
 
     MainWindow w;


### PR DESCRIPTION
Seems the default native qDebug() mechanism got disabled and does
not work in Qt 5.6.2.

The solution was to add a message handler so that the program now
has full control of managing the debug output.