### PR TITLE
main: Add file and directory checks from mainwindow

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,31 @@ int main(int argc, char *argv[])
     a.setStyleSheet(setSheet);
 
     MainWindow w;
+
+    w.uTmaxDir = QDir::homePath();
+    w.uTmaxDir.append("/uTmax_files/");
+    qDebug() << "Home directory:" << w.uTmaxDir;
+    QDir dir(w.uTmaxDir);
+    if(!dir.exists())
+    {
+        qCritical() << "ERROR: Home directory does not exist:" << w.uTmaxDir;
+        std::exit(EXIT_FAILURE);
+    }
+
+    // Read the default tube data file or ask for the file
+    w.dataFileName = w.uTmaxDir;
+    w.dataFileName.append("data.csv");
+    if (!w.ReadDataFile())
+        std::exit(EXIT_FAILURE);
+
+    // Read the calibration file or create a fresh file
+    w.calFileName = w.uTmaxDir;
+    w.calFileName.append("cal.txt");
+    if (!w.ReadCalibration())
+        std::exit(EXIT_FAILURE);
+
+    w.SerialPortDiscovery();
+
     w.show();
     
     return a.exec();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -147,23 +147,7 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->Tabs->setCurrentIndex(0);
     //
     optimizer = new dr_optimize();
-
-    //get paths and define file names
-    //appDir = QCoreApplication.applicationDirPath()
-    uTmaxDir = QDir::homePath();
-    uTmaxDir.append("/uTmax_files/");
-    dataFileName = uTmaxDir;
-    dataFileName.append("data.csv");
-    ReadDataFile();
-    calFileName = uTmaxDir;
-    calFileName.append("cal.txt");
-    ReadCalibration();
-
-    adc_scale.Va=(470000 + calData.RaVal)/calData.RaVal;
-    adc_scale.Vs=(470000 + calData.RaVal)/calData.RaVal;
-    SerialPortDiscovery();
 }
-
 
 MainWindow::~MainWindow()
 {
@@ -1409,14 +1393,19 @@ int MainWindow::GetVf(float v)
 
 //------------------------------------------------------
 // Calibration File Management
-void MainWindow::ReadCalibration()
+bool MainWindow::ReadCalibration()
 {
     //Check to see if the cal file exists
     QFile datafile(calFileName);
+    qDebug() << "Default calibration filename:" << calFileName;
     if (! datafile.exists())
     {
         //It doesn't exist so set up default values and create a file
-        datafile.open(QIODevice::WriteOnly | QIODevice::Text);
+        if (!datafile.open(QIODevice::WriteOnly | QIODevice::Text))
+        {
+            qCritical() << "ERROR: failed to open for writing:" << calFileName;
+            return(false);
+        }
         QTextStream calFile(&datafile);
         calFile << "COM=COM1\n";
         calFile << "Va=1.0\n";
@@ -1447,7 +1436,7 @@ void MainWindow::ReadCalibration()
         }
         calFile.flush();
         datafile.close();
-        //qDebug() << "ReadCalibration: Created new cal file";
+        qDebug() << "ReadCalibration: Created new cal file" << calFileName;
     }
     //Initialize a Pen List-
     int r,g,b,w,h,s,v;
@@ -1468,7 +1457,11 @@ void MainWindow::ReadCalibration()
     black.setColor(QColor::fromRgb(0,0,0,255));
     black.setWidthF(2);
     //Open the cal.txt file
-    datafile.open(QIODevice::ReadOnly | QIODevice::Text);
+    if (!datafile.open(QIODevice::ReadOnly | QIODevice::Text))
+    {
+        qDebug() << "ERROR: failed to open for reading:" << calFileName;
+        return(false);
+    }
     QTextStream in(&datafile);
     while ( !in.atEnd() )
     {
@@ -1514,6 +1507,11 @@ void MainWindow::ReadCalibration()
     m.clear();
     QTextStream(&m) << calData.IaMax << "mA Max";
     ui->labelInfo_3->setText(m);
+
+    adc_scale.Va=(470000 + calData.RaVal)/calData.RaVal;
+    adc_scale.Vs=(470000 + calData.RaVal)/calData.RaVal;
+
+    return(true);
 }
 
 void MainWindow::SaveCalFile()
@@ -1556,16 +1554,21 @@ void MainWindow::SaveCalFile()
 
 //------------------------------------------------------
 // Tube Data file Management
-void MainWindow::ReadDataFile()
+bool MainWindow::ReadDataFile()
 {
     //Check to see if usual data file exists
     QFile datafile(dataFileName);
+    qDebug() << "Default dataFileName:" << dataFileName;
     if (! datafile.exists(dataFileName)) {
         //It doesn't exist so ask for it
-        dataFileName="";
+        dataFileName = QString();
         dataFileName = QFileDialog::getOpenFileName(this,tr("Read Tube Data file"),QDir::homePath(),"Text (*.csv)");
     }
-    if (dataFileName=="") QCoreApplication::quit();
+    if (dataFileName.isNull()) {
+        qWarning() << "WARNING: Valve database .csv file not specified";
+        return(false);
+    }
+    qDebug() << "Using dataFileName: " << dataFileName;
     datafile.setFileName(dataFileName);
     datafile.open(QIODevice::ReadOnly | QIODevice::Text);
     QTextStream in(&datafile);
@@ -1692,6 +1695,7 @@ void MainWindow::ReadDataFile()
     ui->TubeSelector->setCurrentIndex(0);
     on_TubeSelector_currentIndexChanged(tubeDataList->at(0).ID);
     //LabelPins(tubeDataList->at(0)); // should be triggered by change of index;
+    return(true);
 }
 
 void MainWindow::LabelPins(tubeData_t tubeData) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -59,8 +59,9 @@ public:
     calData_t calData;
     QString dataFileName;
     QString calFileName;
-    void ReadCalibration();
-    void ReadDataFile();
+    bool ReadCalibration();
+    bool ReadDataFile();
+    void SerialPortDiscovery();
     ~MainWindow();
 
     void SaveCalFile();
@@ -144,6 +145,7 @@ public:
     QList<QSerialPortInfo> serPortInfo;
     QString comport;
     void OpenComPort(const QString *);
+    QString uTmaxDir;
 
 
 public slots:
@@ -186,7 +188,6 @@ private:
     Ui::MainWindow *ui;
     void PenUpdate();
     void updateLcdsWithModel();
-    void SerialPortDiscovery();
     void updateSweepGreying();
     void updateTubeGreying();
     void CreateTestVectors();
@@ -197,7 +198,6 @@ private:
                     Sweep_set, Sweep_adc, Idle, wait_adc,
                     hold_ack, hold, heat_done,HeatOff};
     Status_t status;
-    QString uTmaxDir;
     int startSweep;
     int VsStep;
     int VgStep;


### PR DESCRIPTION
Bug #1:
The mainwindow constructor defines the path to where the tube data
file and the calibration file are located but fails to check the
path exists.

Without the check, an attempt to write a new calibration file
silently fails.

Therefore, add a check to ensure the path to the data files exists
otherwise exit with an error message.

Bug #2:
If no "data.csv" file exists then a file dialog window is
opened to select the .csv file which contains the Thermionic
Valve / tube data. However, if the "cancel" option is clicked on
then a crash occurs.

Analysis found that the NULL QString test for the selected
file was not working which allowed the code to think that a file
had been selected when in fact the QString was set to NULL by
the returning file dialog due to the cancel operation.

A crash occurred because ReadDataFile() thought that it had
read in the data when in fact it had read no data.

Bug #3
Writing and reading the calibration file has insufficient checks.
Therefore, add checks and debug to assist with diagnosis.

Move the 2 adc_scale lines inside ReadCalibration() because the
adc_scale values are dependent on the calibration information.

Bug #4
The constructor of mainwindow was reading the data.csv which
can fail. Unfortunately, a constructor cannot return an error
code and it is unwise to exit the program from within a constructor.
Therefore, move the reading of the data.csv file into the main
function of main.cpp.

Also reading and writing the calibration file can fail so move
that as well.

In addion move the serial port initialisation into main() to
make it cleaner.

Add some debug, warning and critical error message output.

Signed-off-by: Dean Jenkins <skullandbones99@gmail.com>