### PR TITLE
main: Add workaround for native qDebug not working

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,39 @@
 #include <QtWidgets/QApplication>
 #include "mainwindow.h"
 
+// Workaround for native qDebug() output not working
+void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    QByteArray localMsg = msg.toLocal8Bit();
+
+	// Reduce logging output by only using data that contains line numbers
+    if (!context.line) return;
+
+    switch (type) {
+    case QtDebugMsg:
+        std::fprintf(stderr, "Debug: %s (%s:%u)\n", localMsg.constData(), context.file, context.line);
+        break;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
+    case QtInfoMsg:
+        std::fprintf(stderr, "Info: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        break;
+#endif
+    case QtWarningMsg:
+        std::fprintf(stderr, "Warning: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        break;
+    case QtCriticalMsg:
+        std::fprintf(stderr, "Critical: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        break;
+    case QtFatalMsg:
+        std::fprintf(stderr, "Fatal: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        std::abort();
+    }
+}
+
 int main(int argc, char *argv[])
 {
+    qInstallMessageHandler(myMessageOutput);
+
     QApplication a(argc, argv);
 
     QFile stylesheet("Style.qss");


### PR DESCRIPTION
Seems the default native qDebug() mechanism got disabled and does
not work in Qt 5.6.2.

The solution was to add a message handler so that the program now
has full control of managing the debug output.

Signed-off-by: Dean Jenkins <skullandbones99@gmail.com>
(cherry picked from commit 1bf38aa794fda545fa38f670951647b81addbe0c)

Plus add std:: prefix
Signed-off-by: Dean Jenkins <skullandbones99@gmail.com>