### PR TITLE
main: Add file and directory checks from mainwindow

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,31 @@ int main(int argc, char *argv[])
     a.setStyleSheet(setSheet);
 
     MainWindow w;
+
+    w.uTmaxDir = QDir::homePath();
+    w.uTmaxDir.append("/uTmax_files/");
+    qDebug() << "Home directory:" << w.uTmaxDir;
+    QDir dir(w.uTmaxDir);
+    if(!dir.exists())
+    {
+        qCritical() << "ERROR: Home directory does not exist:" << w.uTmaxDir;
+        return(EXIT_FAILURE);
+    }
+
+    // Read the default tube data file or ask for the file
+    w.dataFileName = w.uTmaxDir;
+    w.dataFileName.append("data.csv");
+    if (!w.ReadDataFile())
+        return(EXIT_FAILURE);
+
+    // Read the calibration file or create a fresh file
+    w.calFileName = w.uTmaxDir;
+    w.calFileName.append("cal.txt");
+    if (!w.ReadCalibration())
+        return(EXIT_FAILURE);
+
+    w.SerialPortDiscovery();
+
     w.show();
     
     return a.exec();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -59,8 +59,9 @@ public:
     calData_t calData;
     QString dataFileName;
     QString calFileName;
-    void ReadCalibration();
-    void ReadDataFile();
+    bool ReadCalibration();
+    bool ReadDataFile();
+    void SerialPortDiscovery();
     ~MainWindow();
 
     void SaveCalFile();
@@ -144,6 +145,7 @@ public:
     QList<QSerialPortInfo> serPortInfo;
     QString comport;
     void OpenComPort(const QString *);
+    QString uTmaxDir;
 
 
 public slots:
@@ -186,7 +188,6 @@ private:
     Ui::MainWindow *ui;
     void PenUpdate();
     void updateLcdsWithModel();
-    void SerialPortDiscovery();
     void updateSweepGreying();
     void updateTubeGreying();
     void CreateTestVectors();
@@ -197,7 +198,6 @@ private:
                     Sweep_set, Sweep_adc, Idle, wait_adc,
                     hold_ack, hold, heat_done,HeatOff};
     Status_t status;
-    QString uTmaxDir;
     int startSweep;
     int VsStep;
     int VgStep;


### PR DESCRIPTION
Bug #1:
The mainwindow constructor defines the path to where the tube data
file and the calibration file are located but fails to check the
path exists.

Without the check, an attempt to write a new calibration file
silently fails.

Therefore, add a check to ensure the path to the data files exists
otherwise exit with an error message.

Bug #2:
If no "data.csv" file exists then a file dialog window is
opened to select the .csv file which contains the Thermionic
Valve / tube data. However, if the "cancel" option is clicked on
then a crash occurs.

Analysis found that the NULL QString test for the selected
file was not working which allowed the code to think that a file
had been selected when in fact the QString was set to NULL by
the returning file dialog due to the cancel operation.

A crash occurred because ReadDataFile() thought that it had
read in the data when in fact it had read no data.

Bug #3
Writing and reading the calibration file has insufficient checks.
Therefore, add checks and debug to assist with diagnosis.

Move the 2 adc_scale lines inside ReadCalibration() because the
adc_scale values are dependent on the calibration information.

Bug #4
The constructor of mainwindow was reading the data.csv which
can fail. Unfortunately, a constructor cannot return an error
code and it is unwise to exit the program from within a constructor.
Therefore, move the reading of the data.csv file into the main
function of main.cpp.

Also reading and writing the calibration file can fail so move
that as well.

In addion move the serial port initialisation into main() to
make it cleaner.

Bug #5
When main() returns using return(EXIT_FAILURE), ~MainWindow()
runs and crashes because portInUse is NULL.

Therefore, add a NULL check for portInUse in ~MainWindow().

In general, add some debug, warning and critical error message output.

Signed-off-by: Dean Jenkins <skullandbones99@gmail.com>