### PR TITLE
Add functions to manage start and stop of the protocol engine plus operation requests

### DIFF
--- a/src/debug_dialog.cpp
+++ b/src/debug_dialog.cpp
@@ -184,11 +184,12 @@ void debug_dialog::on_OK_clicked()
 
 void debug_dialog::on_Ping_clicked()
 {
-    mw->sendADC=true;
+    // Button is actually "Read ADC"
+    mw->RequestOperation((Operation_t) ReadADC);
 }
 
 
 void debug_dialog::on_pushPing_clicked()
 {
-    mw->sendPing=true;
+    mw->RequestOperation((Operation_t) Ping);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -151,12 +151,11 @@ MainWindow::MainWindow(QWidget *parent) :
 
 MainWindow::~MainWindow()
 {
+    qDebug() << "~MainWindow: Destroy everything!";
     delete optimizer;
-    if (timer) {
-        qDebug() << "~MainWindow: Disconnecting timer";
-        disconnect(timer, SIGNAL(timeout()), this, SLOT(RxData()));
-        delete timer;
-    }
+
+    // Stop the machine
+    StopTheMachine();
 
     // Close open port
     CloseComPort();
@@ -227,17 +226,8 @@ bool MainWindow::OpenComPort(const QString *portName, bool updateCalFile)
     }
     ui->statusBar->showMessage(msg);
 
-    // Start RxData Timer
-    if (openResult && timer == NULL)
-    {
-        timer = new QTimer(this);
-        connect(timer, SIGNAL(timeout()), this, SLOT(RxData()));
-        ui->statusBar->showMessage("Starting up...");
-        timer_on=true;
-        timeout=PING_TIMEOUT;
-        sendADC=true;
-        timer->start(TIMER_SET);
-    }
+    // Start the machine
+    if (openResult) StartUpMachine();
 
     return(openResult);
 }
@@ -254,6 +244,35 @@ bool MainWindow::CloseComPort()
         portInUse->close();
         delete portInUse;
         portInUse = NULL;
+    }
+}
+
+void MainWindow::StartUpMachine()
+{
+    // Start up the machine
+    if (!timer)
+    {
+        qDebug() << "StartUpMachine: Starting up the machine!";
+        ui->statusBar->showMessage("Starting up...");
+        timer_on = true;
+        timeout = PING_TIMEOUT;
+        sendADC = true;
+        timer = new QTimer(this);
+        connect(timer, SIGNAL(timeout()), this, SLOT(RxData()));
+        timer->start(TIMER_SET);
+    }
+}
+
+void MainWindow::StopTheMachine()
+{
+    // Stop the machine
+    if (timer)
+    {
+        qDebug() << "StopTheMachine: Destroying the timer";
+        timer->stop();
+        disconnect(timer, SIGNAL(timeout()), this, SLOT(RxData()));
+        delete timer;
+        timer = NULL;
     }
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -151,6 +151,7 @@ public:
     void DataSaveDialog_clicked(const QString &);
     bool OpenComPort(const QString *, bool updateCalFile);
     bool CloseComPort();
+    void RequestOperation(Operation_t ReqOperation);
 
 public slots:
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -294,5 +294,7 @@ private:
     void RePlot(QList<results_t> *);
     bool SaveTubeDataFile();
     int RxPkt(int len, QByteArray *pCmd, QByteArray *pResponse);
+    void StartUpMachine();
+    void StopTheMachine();
 };
 #endif // MAINWINDOW_H

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -33,7 +33,8 @@ struct results_t
     float mu_b;
 };
 
-struct plotInfo_t {
+struct plotInfo_t
+{
     int VaSteps;
     int VsSteps;
     int VgSteps;
@@ -43,15 +44,21 @@ struct plotInfo_t {
     float VsEnd;
     float VgStart;
     float VgEnd;
-    QList<results_t> * dataSet;
+    QList<results_t> *dataSet;
     QString tube;
     QString type;
-    QList<QPen> * penList;
+    QList<QPen> *penList;
     bool penChange;
     bool VsEQVa;
-
-
 };
 
+enum Operation_t
+{
+    Stop,
+    Probe,
+    Ping,
+    ReadADC,
+    Start
+};
 
 #endif // TYPEDEFS_H


### PR DESCRIPTION
The original code uses a timer which runs every 500ms and this timer manages the state machine which uses the serial protocol to control the uTracer 3.

Debug was added to the protocol state machine which revealed that the timer continues to fire after the state machine reaches the full idle state. This is inefficient so add functions to control the creation and destruction of the timer object. This means the timer object only exists when the protocol state machine is running.

In addition, focus the various operation requests through a single function so that the GUI requests can be isolated from the protocol state machine.