### PR TITLE
Implement new serial protocol state machine

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -502,13 +502,12 @@ void MainWindow::RxData()
     static int lim[]={0x8f, 0x8d, 0xad, 0xab, 0x84, 0xa4, 0xa2, 0xa1, 0x80, 0x00};
     static int avg[]={0x40, 1, 2, 4, 8, 16, 32, 0x40};
     static int Ir[]={8,1,2,3,4,5,6,7};
-    static QByteArray cmd;
     static QByteArray response;
     static int distime;
 
     if (sendADC == true)
     {
-        cmd = TxString = "500000000000000000";
+        TxString = "500000000000000000";
         rxLen = TxString.length() + 38;
         heat = 0;
         sendSer(38);
@@ -521,7 +520,7 @@ void MainWindow::RxData()
 
     if (sendPing == true)
     {
-        cmd = TxString = "300000000000000000";
+        TxString = "300000000000000000";
         rxLen = TxString.length();
         heat = 0;
         sendSer(0);
@@ -549,7 +548,6 @@ void MainWindow::RxData()
         ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
         TxString = "300000000000000000";
         response.clear();
-        cmd = TxString;
         rxLen = TxString.length();
         sendSer(0);
         timer_on = false;
@@ -612,7 +610,6 @@ void MainWindow::RxData()
                 TxString += buf;
                 ::snprintf(buf, 3, "%02X", Ir[options.IaRange]);
                 TxString += buf;
-                cmd = TxString;
                 rxLen = 18;
                 sendSer(0);
                 timer_on = true;
@@ -630,7 +627,6 @@ void MainWindow::RxData()
             if (RxCode == RXSUCCESS)
             {
                 rxLen = 0;
-                cmd = "";
                 status = Idle;
                 ui->statusBar->showMessage("Ping OK");
                 timer_on = false;
@@ -644,7 +640,6 @@ void MainWindow::RxData()
             {
                 saveADCInfo(&response);
                 rxLen = 0;
-                cmd = "";
                 status = Idle;
                 ui->statusBar->showMessage("Ready");
                 timer_on = false;
@@ -658,7 +653,7 @@ void MainWindow::RxData()
             {
                 ui->statusBar->showMessage("Heating, get ADC info");
                 status = Heating_wait_adc;
-                cmd = TxString = "500000000000000000";
+                TxString = "500000000000000000";
                 rxLen = TxString.length() + 38;
                 sendSer(38);
                 timer_on = true;
@@ -677,7 +672,6 @@ void MainWindow::RxData()
                 ui->statusBar->showMessage("Heating");
                 TxString = "400000000000000000";
                 rxLen = TxString.length();
-                cmd = TxString;
                 sendSer(0);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -695,7 +689,6 @@ void MainWindow::RxData()
                 ui->HeaterProg->setValue(0);
                 ui->statusBar->showMessage("Heater off");
                 TxString = "400000000000000000";
-                cmd = TxString;
                 rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
@@ -717,7 +710,6 @@ void MainWindow::RxData()
                     ::snprintf(buf, 19, "40000000000000%04X", VfADC);
                     TxString = buf;
                     rxLen = TxString.length();
-                    cmd = TxString;
                     timeout = PING_TIMEOUT;
                     sendSer(0);
                     heat++;
@@ -728,7 +720,6 @@ void MainWindow::RxData()
                     status = heat_done;
                     timer_on = false;
                     rxLen = 0;
-                    cmd = "";
                 }
             }
             break;
@@ -744,7 +735,7 @@ void MainWindow::RxData()
                 stop = false;
                 status = HeatOff;
                 HV_Discharge_Timer = 0;
-                cmd=TxString = "400000000000000000";
+                TxString = "400000000000000000";
                 rxLen=TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
@@ -756,7 +747,6 @@ void MainWindow::RxData()
                 startSweep = 0;
                 if (dataStore->length() > 0) dataStore->clear();
                 rxLen = 0;
-                cmd = "";
                 CreateTestVectors();
                 curve = 0;
                 status = Sweep_set;
@@ -773,7 +763,7 @@ void MainWindow::RxData()
                 distime = (int)(DISTIME * v / 400);
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
-                cmd = TxString = "400000000000000000";
+                TxString = "400000000000000000";
                 rxLen = TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
@@ -795,7 +785,7 @@ void MainWindow::RxData()
                 timeout = ADC_READ_TIMEOUT;
                 timer_on = true;
                 ::snprintf(buf, 19, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC );
-                cmd = TxString= buf;
+                TxString= buf;
                 rxLen= TxString.length() + 38;
                 sendSer(38);
             }
@@ -815,7 +805,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    cmd = TxString;
                     rxLen = TxString.length();
                     sendSer(0);
                     heat=0;
@@ -831,7 +820,7 @@ void MainWindow::RxData()
                 timeout = ADC_READ_TIMEOUT + options.Delay;
                 timer_on = true;
                 sprintf(buf, "20%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
-                cmd = TxString = buf;
+                TxString = buf;
                 rxLen = TxString.length();
                 sendSer(0);
             }
@@ -842,7 +831,6 @@ void MainWindow::RxData()
             status = hold;
             timer_on = false;
             rxLen = 0;
-            cmd = "";
             break;
         }
         case hold:
@@ -856,7 +844,6 @@ void MainWindow::RxData()
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
                 TxString = "400000000000000000";
-                cmd = TxString;
                 rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
@@ -880,7 +867,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    cmd = TxString;
                     rxLen = TxString.length();
                     sendSer(0);
                     heat = 0;
@@ -896,7 +882,7 @@ void MainWindow::RxData()
                 timeout = ADC_READ_TIMEOUT;
                 timer_on = true;
                 sprintf(buf, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
-                cmd = TxString = buf;
+                TxString = buf;
                 rxLen = TxString.length() + 38;
                 sendSer(38);
             }
@@ -906,7 +892,6 @@ void MainWindow::RxData()
                 delay--;
                 status = hold;
                 rxLen = 0;
-                cmd = "";
             }
             break;
         }
@@ -934,7 +919,6 @@ void MainWindow::RxData()
                         HV_Discharge_Timer =distime;
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        cmd = TxString;
                         rxLen = TxString.length();
                         sendSer(0);
                         break;
@@ -983,7 +967,6 @@ void MainWindow::RxData()
                     status = Sweep_set;
                     timeout = ADC_READ_TIMEOUT;
                     rxLen = 0;
-                    cmd = "";
                 }
                 else
                 {
@@ -1004,7 +987,6 @@ void MainWindow::RxData()
                         ui->statusBar->showMessage("Sweep complete");
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        cmd = TxString;
                         rxLen = TxString.length();
                         sendSer(0);
                     }
@@ -1017,7 +999,7 @@ void MainWindow::RxData()
             if (HV_Discharge_Timer>0) HV_Discharge_Timer--;
             if (HV_Discharge_Timer == (distime-1))
             {
-                cmd = TxString = "300000000000000000";
+                TxString = "300000000000000000";
                 rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -97,7 +97,6 @@ MainWindow::MainWindow(QWidget *parent) :
     status=Idle;
     startSweep=0;
     stop=false;
-    timeout=PING_TIMEOUT;
     timer=NULL;
     newMessage=false;
     sendADC=false;
@@ -444,11 +443,11 @@ int MainWindow::RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response)
 {
     int rxStatus = RXCONTINUE;
 
-    if (timeout)
+    if (pSendCmdRsp->timeout)
     {
-        timeout--;
+        pSendCmdRsp->timeout--;
 
-        if (timeout == 0)
+        if (pSendCmdRsp->timeout == 0)
         {
             qDebug() << "RxPkt: TIMEOUT - try reading for missing RX";
             readData();
@@ -468,7 +467,7 @@ int MainWindow::RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response)
         pSendCmdRsp->txState = TxIdle;
         pSendCmdRsp->rxState = RxIdle;
 
-        timeout = 0;
+        pSendCmdRsp->timeout = 0;
 
         // For the debug window
         TxString = pSendCmdRsp->Command;
@@ -501,7 +500,7 @@ void MainWindow::SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uin
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -517,7 +516,7 @@ void MainWindow::SendGetMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint1
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 38;
-    timeout = ADC_READ_TIMEOUT;
+    pSendCmdRsp->timeout = ADC_READ_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -533,7 +532,7 @@ void MainWindow::SendHoldMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = ADC_READ_TIMEOUT + delay;
+    pSendCmdRsp->timeout = ADC_READ_TIMEOUT + delay;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -542,7 +541,7 @@ void MainWindow::SendEndMeasurementCommand(CommandResponse_t *pSendCmdRsp)
     qDebug() << "Send End Measurement command:";
     pSendCmdRsp->Command = "300000000000000000";
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -556,7 +555,7 @@ void MainWindow::SendFilamentCommand(CommandResponse_t *pSendCmdRsp, uint16_t fi
     pSendCmdRsp->Command = temp_buffer;
 
     pSendCmdRsp->ExpectedRspLen = 0;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -565,7 +564,7 @@ void MainWindow::SendADCCommand(CommandResponse_t *pSendCmdRsp)
     qDebug() << "Send ADC command:";
     pSendCmdRsp->Command = "500000000000000000";
     pSendCmdRsp->ExpectedRspLen = 38;
-    timeout = PING_TIMEOUT;
+    pSendCmdRsp->timeout = PING_TIMEOUT;
     SendCommand(pSendCmdRsp, true, 0);
 }
 
@@ -954,7 +953,6 @@ void MainWindow::RxData()
                     ui->statusBar->showMessage(msg);
                     delay = options.Delay;
                     status = Sweep_set;
-                    timeout = ADC_READ_TIMEOUT;
                 }
                 else
                 {
@@ -1003,7 +1001,6 @@ void MainWindow::RxData()
             }
             else
             {
-                timeout = PING_TIMEOUT;
                 QString msg = QString("Countdown for HV to discharge: %1").arg(HV_Discharge_Timer);
                 ui->statusBar->showMessage(msg);
             }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -147,6 +147,11 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->Tabs->setCurrentIndex(0);
     //
     optimizer = new dr_optimize();
+
+    // Initalise the command response structure
+    CmdRsp.txState = TxIdle;
+    CmdRsp.rxState = RxIdle;
+    CmdRsp.timeout = 0;
 }
 
 MainWindow::~MainWindow()
@@ -323,9 +328,6 @@ void MainWindow::StopTheMachine()
     }
 }
 
-// Temporarily file global
-CommandResponse_t CmdRsp;
-
 void MainWindow::SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar)
 {
     static CommandResponse_t *pSendCmdRsp = NULL;
@@ -440,11 +442,9 @@ void MainWindow::readData()
     }
 }
 
-int MainWindow::RxPkt(QByteArray *response)
+int MainWindow::RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response)
 {
     int rxStatus = RXCONTINUE;
-    // Temporary
-    CommandResponse_t *pSendCmdRsp = &CmdRsp;
 
     if (timeout)
     {
@@ -542,7 +542,7 @@ void MainWindow::RxData()
 
     // ---------------------------------------------------
     // Check for the uTracer response
-    int RxCode = RxPkt(&response);
+    int RxCode = RxPkt(&CmdRsp, &response);
     // Check for timeout
     if (RxCode == RXTIMEOUT && timer_on)
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -440,41 +440,54 @@ void MainWindow::readData()
     }
 }
 
-int MainWindow::RxPkt(int len, QByteArray *cmd, QByteArray *response)
+int MainWindow::RxPkt(QByteArray *response)
 {
-    if (len==0) return RXCONTINUE;
-    timeout--;
-    if (timeout == 0)
+    int rxStatus = RXCONTINUE;
+    // Temporary
+    CommandResponse_t *pSendCmdRsp = &CmdRsp;
+
+    if (timeout)
     {
-        RxString.clear();
+        timeout--;
+
+        if (timeout == 0)
+        {
+            qDebug() << "RxPkt: TIMEOUT - try reading for missing RX";
+            readData();
+
+            rxStatus = RXTIMEOUT;
+        }
+    }
+
+    if (pSendCmdRsp->rxState == RxComplete)
+    {
+        if (pSendCmdRsp->Response.length())
+        {
+            qDebug() << "RxPkt: Processing RX response:" << pSendCmdRsp->Response;
+            *response = pSendCmdRsp->Response;
+        }
+
+        pSendCmdRsp->txState = TxIdle;
+        pSendCmdRsp->rxState = RxIdle;
+
+        timeout = 0;
+
+        // For the debug window
+        echoString = pSendCmdRsp->Command;
+        statusString = pSendCmdRsp->Response;
+
+        rxStatus = RXSUCCESS;
+    }
+
+    if (rxStatus == RXTIMEOUT)
+    {
+        // Failed to recover, so abandon the command / response
         response->clear();
-        qDebug() << "RxPkt: TIMEOUT";
-        return RXTIMEOUT;
+        pSendCmdRsp->txState = TxIdle;
+        pSendCmdRsp->rxState = RxIdle;
     }
-    if (RxString.length() >= len)
-    {
-        if ((cmd->length() == 0) || RxString.startsWith(*cmd))
-        {
-            *response = RxString.mid(cmd->length(), len);
-            RxString.clear();
-            if (len == 18) echoString = TxString;
-            if (len == 38 + 18)
-            {
-                echoString = TxString;
-                statusString = response->constData();
-            }
-            cmd->clear();
-            return RXSUCCESS;
-        }
-        else
-        {
-            qDebug() << "RxPkt: reply invalid=" << RxString;
-            RxString.clear();
-            response->clear();
-            return RXINVALID;
-        }
-    }
-    return RXCONTINUE;
+
+    return rxStatus;
 }
 //---------------------------------------------
 // The main control process
@@ -529,7 +542,7 @@ void MainWindow::RxData()
 
     // ---------------------------------------------------
     // Check for the uTracer response
-    int RxCode = RxPkt(rxLen, &cmd, &response);
+    int RxCode = RxPkt(&response);
     // Check for timeout
     if (RxCode == RXTIMEOUT && timer_on)
     {
@@ -712,7 +725,6 @@ void MainWindow::RxData()
                 else
                 {
                     ui->HeaterProg->setValue(100);
-                    timeout = PING_TIMEOUT;
                     status = heat_done;
                     timer_on = false;
                     rxLen = 0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -494,7 +494,6 @@ void MainWindow::RxData()
 {
     static int time;
     static int delay;
-    static int rxLen;
     static int HV_Discharge_Timer;
     char buf[30];
     //I Limits         200,  175,  150,  125, 100,    50,   25,   12,  7mA,  Off
@@ -507,7 +506,6 @@ void MainWindow::RxData()
     if (sendADC == true)
     {
         TxString = "500000000000000000";
-        rxLen = TxString.length() + 38;
         heat = 0;
         sendSer(38);
         sendADC = false;
@@ -520,7 +518,6 @@ void MainWindow::RxData()
     if (sendPing == true)
     {
         TxString = "300000000000000000";
-        rxLen = TxString.length();
         heat = 0;
         sendSer(0);
         sendPing = false;
@@ -547,7 +544,6 @@ void MainWindow::RxData()
         ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
         TxString = "300000000000000000";
         response.clear();
-        rxLen = TxString.length();
         sendSer(0);
         timer_on = false;
         status = Idle;
@@ -559,7 +555,6 @@ void MainWindow::RxData()
     {
         ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
         response.clear();
-        rxLen = 0;
         timer_on = false;
         status = Idle;
         return;
@@ -572,7 +567,6 @@ void MainWindow::RxData()
     {
         case Idle:
         {
-            rxLen = 0;
             timer_on = false;
             time = 0;
 
@@ -609,7 +603,6 @@ void MainWindow::RxData()
                 TxString += buf;
                 ::snprintf(buf, 3, "%02X", Ir[options.IaRange]);
                 TxString += buf;
-                rxLen = 18;
                 sendSer(0);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -625,7 +618,6 @@ void MainWindow::RxData()
         {
             if (RxCode == RXSUCCESS)
             {
-                rxLen = 0;
                 status = Idle;
                 ui->statusBar->showMessage("Ping OK");
                 timer_on = false;
@@ -638,7 +630,6 @@ void MainWindow::RxData()
             if (RxCode == RXSUCCESS)
             {
                 saveADCInfo(&response);
-                rxLen = 0;
                 status = Idle;
                 ui->statusBar->showMessage("Ready");
                 timer_on = false;
@@ -653,7 +644,6 @@ void MainWindow::RxData()
                 ui->statusBar->showMessage("Heating, get ADC info");
                 status = Heating_wait_adc;
                 TxString = "500000000000000000";
-                rxLen = TxString.length() + 38;
                 sendSer(38);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -670,7 +660,6 @@ void MainWindow::RxData()
                 status = Heating;
                 ui->statusBar->showMessage("Heating");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
@@ -688,7 +677,6 @@ void MainWindow::RxData()
                 ui->HeaterProg->setValue(0);
                 ui->statusBar->showMessage("Heater off");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
                 timeout = PING_TIMEOUT;
@@ -708,7 +696,6 @@ void MainWindow::RxData()
                     if (VfADC > 1023) VfADC = 1023;
                     ::snprintf(buf, 19, "40000000000000%04X", VfADC);
                     TxString = buf;
-                    rxLen = TxString.length();
                     timeout = PING_TIMEOUT;
                     sendSer(0);
                     heat++;
@@ -718,7 +705,6 @@ void MainWindow::RxData()
                     ui->HeaterProg->setValue(100);
                     status = heat_done;
                     timer_on = false;
-                    rxLen = 0;
                 }
             }
             break;
@@ -735,7 +721,6 @@ void MainWindow::RxData()
                 status = HeatOff;
                 HV_Discharge_Timer = 0;
                 TxString = "400000000000000000";
-                rxLen=TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
                 timeout = PING_TIMEOUT;
@@ -745,7 +730,6 @@ void MainWindow::RxData()
             {
                 startSweep = 0;
                 if (dataStore->length() > 0) dataStore->clear();
-                rxLen = 0;
                 CreateTestVectors();
                 curve = 0;
                 status = Sweep_set;
@@ -763,7 +747,6 @@ void MainWindow::RxData()
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 ui->CaptureProg->setValue(0);
                 timeout = PING_TIMEOUT;
@@ -785,7 +768,6 @@ void MainWindow::RxData()
                 timer_on = true;
                 ::snprintf(buf, 19, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC );
                 TxString= buf;
-                rxLen= TxString.length() + 38;
                 sendSer(38);
             }
             else
@@ -804,7 +786,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    rxLen = TxString.length();
                     sendSer(0);
                     heat=0;
                     timeout = PING_TIMEOUT;
@@ -820,7 +801,6 @@ void MainWindow::RxData()
                 timer_on = true;
                 sprintf(buf, "20%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
                 TxString = buf;
-                rxLen = TxString.length();
                 sendSer(0);
             }
             break;
@@ -829,7 +809,6 @@ void MainWindow::RxData()
         {
             status = hold;
             timer_on = false;
-            rxLen = 0;
             break;
         }
         case hold:
@@ -843,7 +822,6 @@ void MainWindow::RxData()
                 HV_Discharge_Timer = distime;
                 ui->statusBar->showMessage("Abort:Heater off");
                 TxString = "400000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
                 timeout = PING_TIMEOUT;
@@ -866,7 +844,6 @@ void MainWindow::RxData()
                     HV_Discharge_Timer = distime;
                     ui->statusBar->showMessage("Abort:Heater off");
                     TxString = "400000000000000000";
-                    rxLen = TxString.length();
                     sendSer(0);
                     heat = 0;
                     timeout = PING_TIMEOUT;
@@ -882,7 +859,6 @@ void MainWindow::RxData()
                 timer_on = true;
                 sprintf(buf, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
                 TxString = buf;
-                rxLen = TxString.length() + 38;
                 sendSer(38);
             }
             else
@@ -890,7 +866,6 @@ void MainWindow::RxData()
                 ui->statusBar->showMessage("Sweep (Holding)");
                 delay--;
                 status = hold;
-                rxLen = 0;
             }
             break;
         }
@@ -918,7 +893,6 @@ void MainWindow::RxData()
                         HV_Discharge_Timer =distime;
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        rxLen = TxString.length();
                         sendSer(0);
                         break;
                     }
@@ -965,7 +939,6 @@ void MainWindow::RxData()
                     delay = options.Delay;
                     status = Sweep_set;
                     timeout = ADC_READ_TIMEOUT;
-                    rxLen = 0;
                 }
                 else
                 {
@@ -986,7 +959,6 @@ void MainWindow::RxData()
                         ui->statusBar->showMessage("Sweep complete");
                         ui->CaptureProg->setValue(100);
                         TxString = "400000000000000000";
-                        rxLen = TxString.length();
                         sendSer(0);
                     }
                 }
@@ -999,7 +971,6 @@ void MainWindow::RxData()
             if (HV_Discharge_Timer == (distime-1))
             {
                 TxString = "300000000000000000";
-                rxLen = TxString.length();
                 sendSer(0);
                 heat = 0;
                 ui->HeaterProg->setValue(0);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -436,7 +436,6 @@ void MainWindow::readData()
         while (portInUse->bytesAvailable())
         {
             rxChar = portInUse->read(1).at(0);
-            RxString.append(rxChar);
             SendCommand(NULL, false, rxChar);
         }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -323,9 +323,121 @@ void MainWindow::StopTheMachine()
     }
 }
 
+// Temporarily file global
+CommandResponse_t CmdRsp;
+
+void MainWindow::SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar)
+{
+    static CommandResponse_t *pSendCmdRsp = NULL;
+    QByteArray txChar;
+
+    if (txLoad)
+    {
+        pSendCmdRsp = pCmdRsp;
+        pSendCmdRsp->txState = TxLoaded;
+    }
+
+    switch (pSendCmdRsp->txState)
+    {
+        case TxLoaded:
+        {
+            pSendCmdRsp->txPos = 0;
+            pSendCmdRsp->rxPos = 0;
+            pSendCmdRsp->Response.clear();
+            qDebug() << "SendCommand: TX loaded, Cmd len:" << pSendCmdRsp->Command.length() \
+                     << "Expected Response len:" << pSendCmdRsp->ExpectedRspLen;
+
+            // Transmit the first character
+            txChar.append(pSendCmdRsp->Command.at(pSendCmdRsp->txPos));
+            qDebug() << "SendCommand: send char:" << txChar;
+            if (portInUse) portInUse->write(txChar);
+            pSendCmdRsp->txState = TxSending;
+            pSendCmdRsp->rxState = RxIdle;
+            break;
+        }
+        case TxSending:
+        {
+            // Check TX was echoed OK
+            if (rxChar == pSendCmdRsp->Command.at(pSendCmdRsp->txPos))
+            {
+                pSendCmdRsp->rxState = RxEchoed;
+                qDebug() << "SendCommand: RX Echo:" << rxChar;
+            }
+            else
+            {
+                pSendCmdRsp->rxState = RxEchoError;
+                qDebug() << "ERROR: SendCommand: Echo failed:" << rxChar;
+                pSendCmdRsp->txState = TxIdle;
+                break;
+            }
+
+            pSendCmdRsp->txPos++;
+
+            if (pSendCmdRsp->txPos < pSendCmdRsp->Command.length())
+            {
+                // Transmit the next character
+                txChar.append(pSendCmdRsp->Command.at(pSendCmdRsp->txPos));
+                qDebug() << "SendCommand: send char:" << txChar;
+                if (portInUse) portInUse->write(txChar);
+            }
+            else
+            {
+                if (pSendCmdRsp->rxPos == pSendCmdRsp->ExpectedRspLen)
+                {
+                    // No response message was expected
+                    qDebug() << "SendCommand: RX response: None";
+                    pSendCmdRsp->rxState = RxComplete;
+                    pSendCmdRsp->txState = TxComplete;
+                }
+                else
+                {
+                    // Now receiving the RX response message
+                    qDebug() << "SendCommand: RX response: Wait for message";
+                    pSendCmdRsp->rxState = RxResponse;
+                    pSendCmdRsp->txState = TxRxing;
+                }
+            }
+            break;
+        }
+        case TxRxing:
+        {
+            if (pSendCmdRsp->rxPos < pSendCmdRsp->ExpectedRspLen)
+            {
+                // Receiving the RX response message
+                qDebug() << "SendCommand: RX response:" << rxChar;
+                pSendCmdRsp->Response.append(rxChar);
+                pSendCmdRsp->rxState = RxResponse;
+                pSendCmdRsp->rxPos++;
+            }
+            if (pSendCmdRsp->rxPos == pSendCmdRsp->ExpectedRspLen)
+            {
+                // Received the complete RX response message
+                qDebug() << "SendCommand: RX response: Complete";
+                pSendCmdRsp->rxState = RxComplete;
+                pSendCmdRsp->txState = TxComplete;
+            }
+            break;
+        }
+        default:
+        {
+            qDebug() << "ERROR: SendCommand: Unknown TX state:" << pSendCmdRsp->txState;
+        }
+    }
+}
+
 void MainWindow::readData()
 {
-    if (portInUse) RxString.append(portInUse->readAll());
+    char rxChar;
+
+    if (portInUse)
+    {
+        while (portInUse->bytesAvailable())
+        {
+            rxChar = portInUse->read(1).at(0);
+            RxString.append(rxChar);
+            SendCommand(NULL, false, rxChar);
+        }
+    }
 }
 
 int MainWindow::RxPkt(int len, QByteArray *cmd, QByteArray *response)
@@ -386,7 +498,7 @@ void MainWindow::RxData()
         cmd = TxString = "500000000000000000";
         rxLen = TxString.length() + 38;
         heat = 0;
-        sendSer();
+        sendSer(38);
         sendADC = false;
         status = wait_adc;
         timeout = PING_TIMEOUT;
@@ -399,7 +511,7 @@ void MainWindow::RxData()
         cmd = TxString = "300000000000000000";
         rxLen = TxString.length();
         heat = 0;
-        sendSer();
+        sendSer(0);
         sendPing = false;
         status = WaitPing;
         timeout = PING_TIMEOUT;
@@ -426,7 +538,7 @@ void MainWindow::RxData()
         response.clear();
         cmd = TxString;
         rxLen = TxString.length();
-        sendSer();
+        sendSer(0);
         timer_on = false;
         status = Idle;
         return;
@@ -489,7 +601,7 @@ void MainWindow::RxData()
                 TxString += buf;
                 cmd = TxString;
                 rxLen = 18;
-                sendSer();
+                sendSer(0);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
             }
@@ -535,7 +647,7 @@ void MainWindow::RxData()
                 status = Heating_wait_adc;
                 cmd = TxString = "500000000000000000";
                 rxLen = TxString.length() + 38;
-                sendSer();
+                sendSer(38);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
             }
@@ -553,7 +665,7 @@ void MainWindow::RxData()
                 TxString = "400000000000000000";
                 rxLen = TxString.length();
                 cmd = TxString;
-                sendSer();
+                sendSer(0);
                 timer_on = true;
                 timeout = PING_TIMEOUT;
                 heat = 1;
@@ -572,7 +684,7 @@ void MainWindow::RxData()
                 TxString = "400000000000000000";
                 cmd = TxString;
                 rxLen = TxString.length();
-                sendSer();
+                sendSer(0);
                 heat = 0;
                 timeout = PING_TIMEOUT;
                 timer_on = true;
@@ -594,7 +706,7 @@ void MainWindow::RxData()
                     rxLen = TxString.length();
                     cmd = TxString;
                     timeout = PING_TIMEOUT;
-                    sendSer();
+                    sendSer(0);
                     heat++;
                 }
                 else
@@ -622,7 +734,7 @@ void MainWindow::RxData()
                 HV_Discharge_Timer = 0;
                 cmd=TxString = "400000000000000000";
                 rxLen=TxString.length();
-                sendSer();
+                sendSer(0);
                 ui->CaptureProg->setValue(0);
                 timeout = PING_TIMEOUT;
                 timer_on = true;
@@ -651,7 +763,7 @@ void MainWindow::RxData()
                 ui->statusBar->showMessage("Abort:Heater off");
                 cmd = TxString = "400000000000000000";
                 rxLen = TxString.length();
-                sendSer();
+                sendSer(0);
                 ui->CaptureProg->setValue(0);
                 timeout = PING_TIMEOUT;
                 timer_on = true;
@@ -673,7 +785,7 @@ void MainWindow::RxData()
                 ::snprintf(buf, 19, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC );
                 cmd = TxString= buf;
                 rxLen= TxString.length() + 38;
-                sendSer();
+                sendSer(38);
             }
             else
             {
@@ -693,7 +805,7 @@ void MainWindow::RxData()
                     TxString = "400000000000000000";
                     cmd = TxString;
                     rxLen = TxString.length();
-                    sendSer();
+                    sendSer(0);
                     heat=0;
                     timeout = PING_TIMEOUT;
                     timer_on = true;
@@ -709,7 +821,7 @@ void MainWindow::RxData()
                 sprintf(buf, "20%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
                 cmd = TxString = buf;
                 rxLen = TxString.length();
-                sendSer();
+                sendSer(0);
             }
             break;
         }
@@ -734,7 +846,7 @@ void MainWindow::RxData()
                 TxString = "400000000000000000";
                 cmd = TxString;
                 rxLen = TxString.length();
-                sendSer();
+                sendSer(0);
                 heat = 0;
                 timeout = PING_TIMEOUT;
                 timer_on = true;
@@ -758,7 +870,7 @@ void MainWindow::RxData()
                     TxString = "400000000000000000";
                     cmd = TxString;
                     rxLen = TxString.length();
-                    sendSer();
+                    sendSer(0);
                     heat = 0;
                     timeout = PING_TIMEOUT;
                     timer_on = true;
@@ -774,7 +886,7 @@ void MainWindow::RxData()
                 sprintf(buf, "10%04X%04X%04X%04X", VaADC, VsADC, VgADC, VfADC);
                 cmd = TxString = buf;
                 rxLen = TxString.length() + 38;
-                sendSer();
+                sendSer(38);
             }
             else
             {
@@ -812,7 +924,7 @@ void MainWindow::RxData()
                         TxString = "400000000000000000";
                         cmd = TxString;
                         rxLen = TxString.length();
-                        sendSer();
+                        sendSer(0);
                         break;
                     }
                 }
@@ -882,7 +994,7 @@ void MainWindow::RxData()
                         TxString = "400000000000000000";
                         cmd = TxString;
                         rxLen = TxString.length();
-                        sendSer();
+                        sendSer(0);
                     }
                 }
             }
@@ -895,7 +1007,7 @@ void MainWindow::RxData()
             {
                 cmd = TxString = "300000000000000000";
                 rxLen = TxString.length();
-                sendSer();
+                sendSer(0);
                 heat = 0;
                 ui->HeaterProg->setValue(0);
                 timeout = PING_TIMEOUT;
@@ -923,12 +1035,11 @@ void MainWindow::RxData()
     }
 }
 
-void MainWindow::sendSer()
+void MainWindow::sendSer(int ExpectedRspLen)
 {
-    //qDebug() << "Tx:" << TxString;
-    //while (!serQueue.isEmpty()) {serQueue.dequeue();}
-    //RxString.clear();
-    if (portInUse) portInUse->write(TxString);
+    CmdRsp.Command = TxString;
+    CmdRsp.ExpectedRspLen = ExpectedRspLen;
+    SendCommand(&CmdRsp, true, 0);
 }
 
 // ------------------

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -201,7 +201,6 @@ private:
     QTimer *timer;
     bool ok;
     bool newMessage;
-    QByteArray RxString;
     float Vdi;
     float power;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -285,7 +285,7 @@ private:
     int GetVs(float);
     int GetVg(float);
     int GetVf(float);
-    void sendSer();
+    void sendSer(int ExpectedRspLen);
     void StoreData(bool);
     void SetUpPlot();
     bool SetUpSweepParams();
@@ -297,5 +297,6 @@ private:
     int RxPkt(int len, QByteArray *pCmd, QByteArray *pResponse);
     void StartUpMachine();
     void StopTheMachine();
+    void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
 };
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -294,7 +294,7 @@ private:
     void DoPlot(plotInfo_t *);
     void RePlot(QList<results_t> *);
     bool SaveTubeDataFile();
-    int RxPkt(int len, QByteArray *pCmd, QByteArray *pResponse);
+    int RxPkt(QByteArray *pResponse);
     void StartUpMachine();
     void StopTheMachine();
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -273,6 +273,37 @@ private:
 
     QSerialPort *portInUse;
 
+    enum RxState_t
+    {
+        RxIdle,
+        RxEchoed,
+        RxEchoError,
+        RxResponse,
+        RxComplete
+    };
+
+    enum TxState_t
+    {
+        TxIdle,
+        TxLoaded,
+        TxSending,
+        TxRxing,
+        TxComplete
+    };
+
+    struct CommandResponse_t
+    {
+        QByteArray Command;
+        int txPos;
+        TxState_t txState;
+        int ExpectedRspLen;
+        QByteArray Response;
+        int rxPos;
+        RxState_t rxState;
+    };
+
+    CommandResponse_t CmdRsp;
+
     // Function protoypes
     void PenUpdate();
     void updateLcdsWithModel();
@@ -294,7 +325,7 @@ private:
     void DoPlot(plotInfo_t *);
     void RePlot(QList<results_t> *);
     bool SaveTubeDataFile();
-    int RxPkt(QByteArray *pResponse);
+    int RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response);
     void StartUpMachine();
     void StopTheMachine();
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -196,7 +196,6 @@ private:
     int curve;
     int heat;
     bool stop;
-    int timeout;
     QTimer *timer;
     bool ok;
     bool newMessage;
@@ -298,6 +297,7 @@ private:
         QByteArray Response;
         int rxPos;
         RxState_t rxState;
+        int timeout;
     };
 
     CommandResponse_t CmdRsp;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -196,7 +196,6 @@ private:
     int curve;
     int heat;
     bool stop;
-    bool timer_on;
     int timeout;
     QTimer *timer;
     bool ok;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -314,7 +314,6 @@ private:
     int GetVs(float);
     int GetVg(float);
     int GetVf(float);
-    void sendSer(int ExpectedRspLen);
     void StoreData(bool);
     void SetUpPlot();
     bool SetUpSweepParams();
@@ -327,5 +326,14 @@ private:
     void StartUpMachine();
     void StopTheMachine();
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);
+    void SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint8_t limits, uint8_t averaging,
+                                     uint8_t screenGain, uint8_t anodeGain);
+    void SendGetMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint16_t anodeV, uint16_t screenV,
+                                   uint16_t gridV, uint16_t filamentV);
+    void SendHoldMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint16_t anodeV, uint16_t screenV,
+                                    uint16_t gridV, uint16_t filamentV, int delay);
+    void SendEndMeasurementCommand(CommandResponse_t *pSendCmdRsp);
+    void SendFilamentCommand(CommandResponse_t *pSendCmdRsp, uint16_t filament);
+    void SendADCCommand(CommandResponse_t *pSendCmdRsp);
 };
 #endif // MAINWINDOW_H

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -61,36 +61,4 @@ enum Operation_t
     Start
 };
 
-// Temporarily global
-enum RxState_t
-{
-    RxIdle,
-    RxEchoed,
-    RxEchoError,
-    RxResponse,
-    RxComplete
-};
-
-// Temporarily global
-enum TxState_t
-{
-    TxIdle,
-    TxLoaded,
-    TxSending,
-    TxRxing,
-    TxComplete
-};
-
-// Temporarily global
-struct CommandResponse_t
-{
-    QByteArray Command;
-    int txPos;
-    TxState_t txState;
-    int ExpectedRspLen;
-    QByteArray Response;
-    int rxPos;
-    RxState_t rxState;
-};
-
 #endif // TYPEDEFS_H

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -61,4 +61,36 @@ enum Operation_t
     Start
 };
 
+// Temporarily global
+enum RxState_t
+{
+    RxIdle,
+    RxEchoed,
+    RxEchoError,
+    RxResponse,
+    RxComplete
+};
+
+// Temporarily global
+enum TxState_t
+{
+    TxIdle,
+    TxLoaded,
+    TxSending,
+    TxRxing,
+    TxComplete
+};
+
+// Temporarily global
+struct CommandResponse_t
+{
+    QByteArray Command;
+    int txPos;
+    TxState_t txState;
+    int ExpectedRspLen;
+    QByteArray Response;
+    int rxPos;
+    RxState_t rxState;
+};
+
 #endif // TYPEDEFS_H


### PR DESCRIPTION
Add SendCommand() to implement a state machine to handle the Data Protocol of the uTracer.

```
The state machine manages the following:

1. Manages TX and RX states transitions.

2. Transmits single characters of the command message and checks that
   the character is echoed. Therefore, a communications failure can
   be detected such as the uTracer not being present.

3. Handles switches between sending a command message and, if expected,
   receiving a message. This is half-duplex; a command and response
   cannot occur at the same time.

4. Uses a structure to hold the messages and states. This allows for
   potential flexibility such as dynamic allocation of the structures.

This solution is an improvement on the original design because this
design is more concise. Also, the design follows the design of the protocol
more closely such as enforcing half-duplex transmission / reception.
```
Abstract the uTracer protocol messages into specific functions which create the command messages and read the resulting response (if any). This simplifies the main state machine by moving that code into specific functions.

Note that CommandResponse_t CmdRsp was made temporarily global during the integration of the changes but is now private.

Modify RxPkt() to use the output from the new state machine. However, retain the original protocol timeout mechanism.

Remove the following variables which are now redundant:
cmd
RxString
rxlen
timer_on