### PR TITLE
Code improvements to RxData() and RxPkt()

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -582,6 +582,7 @@ void MainWindow::RxData()
     static int Ir[]={8,1,2,3,4,5,6,7};
     static QByteArray response;
     static int distime;
+    int RxCode;
 
     // ---------------------------------------------------
     // Sanity check that the port is still OK
@@ -599,6 +600,30 @@ void MainWindow::RxData()
         return;
     }
 
+    // ---------------------------------------------------
+    // Check for the uTracer response
+    RxCode = RxPkt(&CmdRsp, &response);
+    // Check for timeout
+    if (RxCode == RXTIMEOUT)
+    {
+        qDebug() << "RxData: Action RxCode RXTIMEOUT";
+        ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
+        status = Idle;
+        StopTheMachine();
+        return;
+    }
+
+    // Check for invalid response
+    if (RxCode == RXINVALID)
+    {
+        qDebug() << "RxData: Action RxCode RXINVALID";
+        ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
+        status = Idle;
+        StopTheMachine();
+        return;
+    }
+
+    // ---------------------------------------------------
     if (sendADC == true)
     {
         qDebug() << "RxData: Action sendADC";
@@ -616,30 +641,6 @@ void MainWindow::RxData()
         SendEndMeasurementCommand(&CmdRsp);
         status = WaitPing;
         sendPing = false;
-        return;
-    }
-
-    // ---------------------------------------------------
-    // Check for the uTracer response
-    int RxCode = RxPkt(&CmdRsp, &response);
-    // Check for timeout
-    if (RxCode == RXTIMEOUT)
-    {
-        qDebug() << "RxData: Action RxCode RXTIMEOUT";
-        ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
-        SendEndMeasurementCommand(&CmdRsp);
-        response.clear();
-        status = Idle;
-        return;
-    }
-
-    // Check for invalid rsponse
-    if (RxCode == RXINVALID)
-    {
-        qDebug() << "RxData: Action RxCode RXINVALID";
-        ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
-        response.clear();
-        status = Idle;
         return;
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -579,7 +579,6 @@ void MainWindow::RxData()
     static int time;
     static int delay;
     static int HV_Discharge_Timer;
-    char buf[30];
     //I Limits         200,  175,  150,  125, 100,    50,   25,   12,  7mA,  Off
     static int lim[]={0x8f, 0x8d, 0xad, 0xab, 0x84, 0xa4, 0xa2, 0xa1, 0x80, 0x00};
     static int avg[]={0x40, 1, 2, 4, 8, 16, 32, 0x40};

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1022,6 +1022,13 @@ void MainWindow::RxData()
                 QString msg = QString("Countdown for HV to discharge: %1").arg(HV_Discharge_Timer);
                 ui->statusBar->showMessage(msg);
             }
+            break;
+        }
+        default:
+        {
+            qCritical() << "ERROR: unknown status:" << status;
+            StopTheMachine();
+            break;
         }
     }
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -585,6 +585,7 @@ void MainWindow::RxData()
 
     if (sendADC == true)
     {
+        qDebug() << "RxData: Action sendADC";
         heat = 0;
         SendADCCommand(&CmdRsp);
         status = wait_adc;
@@ -594,6 +595,7 @@ void MainWindow::RxData()
 
     if (sendPing == true)
     {
+        qDebug() << "RxData: Action sendPing";
         heat = 0;
         SendEndMeasurementCommand(&CmdRsp);
         status = WaitPing;
@@ -615,6 +617,7 @@ void MainWindow::RxData()
     // Check for timeout
     if (RxCode == RXTIMEOUT)
     {
+        qDebug() << "RxData: Action RxCode RXTIMEOUT";
         ui->statusBar->showMessage("No response from uTracer. Check cables and power cycle");
         SendEndMeasurementCommand(&CmdRsp);
         response.clear();
@@ -625,6 +628,7 @@ void MainWindow::RxData()
     // Check for invalid rsponse
     if (RxCode == RXINVALID)
     {
+        qDebug() << "RxData: Action RxCode RXINVALID";
         ui->statusBar->showMessage("Unexpected response from uTracer; power cycle and restart");
         response.clear();
         status = Idle;
@@ -634,6 +638,8 @@ void MainWindow::RxData()
     // ---------------------------------------------------
     // Main state machine
     // Check state
+    qDebug() << "RxData: status:" << status << ":" << status_name[status];
+
     switch (status)
     {
         case Idle:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -583,6 +583,22 @@ void MainWindow::RxData()
     static QByteArray response;
     static int distime;
 
+    // ---------------------------------------------------
+    // Sanity check that the port is still OK
+    if (!portInUse)
+    {
+        ui->statusBar->showMessage("ERROR: The serial port is not available");
+        StopTheMachine();
+        return;
+    }
+
+    if (portInUse && !portInUse->isOpen())
+    {
+        ui->statusBar->showMessage("ERROR: The serial port closed unexpectedly!");
+        StopTheMachine();
+        return;
+    }
+
     if (sendADC == true)
     {
         qDebug() << "RxData: Action sendADC";
@@ -600,14 +616,6 @@ void MainWindow::RxData()
         SendEndMeasurementCommand(&CmdRsp);
         status = WaitPing;
         sendPing = false;
-        return;
-    }
-
-    // ---------------------------------------------------
-    // Sanity check that the port is still OK
-    if (!portInUse || !portInUse->isOpen())
-    {
-        ui->statusBar->showMessage("COM port was closed, exit and restart.");
         return;
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -333,6 +333,11 @@ void MainWindow::SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxCha
 
     if (txLoad)
     {
+        if (pSendCmdRsp) {
+            if (pSendCmdRsp->txState != TxIdle)
+                qCritical() << "ERROR: SendCommand: Attempting to send new message before previous message completed!" \
+                            << pSendCmdRsp->txState;
+        }
         pSendCmdRsp = pCmdRsp;
         pSendCmdRsp->txState = TxLoaded;
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -457,7 +457,6 @@ void MainWindow::RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response, RxS
     }
     else
     {
-        qDebug() << "RxPkt: RXIDLE";
         *pRxStatus = RXIDLE;
     }
 
@@ -490,6 +489,8 @@ void MainWindow::RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response, RxS
         pSendCmdRsp->txState = TxIdle;
         pSendCmdRsp->rxState = RxIdle;
     }
+
+    qDebug() << "RxPkt: RxStatus is:" << RxStatusName[*pRxStatus];
 }
 
 void MainWindow::SendStartMeasurementCommand(CommandResponse_t *pSendCmdRsp, uint8_t limits, uint8_t averaging,

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -308,8 +308,12 @@ private:
         RXCONTINUE,
         RXIDLE,
         RXTIMEOUT,
-        RXINVALID
+        RXINVALID,
+        RXMAX
     };
+
+    QString RxStatusName[RXMAX] = {"RXSUCCESS", "RXCONTINUE", "RXIDLE",
+                                   "RXTIMEOUT", "RXINVALID"};
 
     // Function protoypes
     void PenUpdate();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -184,11 +184,14 @@ private:
     // Type and variable declarations
     Ui::MainWindow *ui;
 
-
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
-                    hold_ack, hold, heat_done,HeatOff};
+                    hold_ack, hold, heat_done, HeatOff};
     Status_t status;
+    QString status_name[HeatOff + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
+                                        "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
+                                        "hold_ack", "hold", "heat_done", "HeatOff"};
+
     int startSweep;
     int VsStep;
     int VgStep;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -4,10 +4,7 @@
 #define TIMER_SET 500
 #define ADC_READ_TIMEOUT (30000/TIMER_SET)
 #define PING_TIMEOUT (5000/TIMER_SET)
-#define RXSUCCESS 1
-#define RXTIMEOUT -1
-#define RXCONTINUE 0
-#define RXINVALID -2
+
 #define HEAT_CNT_MAX 20
 #define HEAT_WAIT_SECS 60
 
@@ -305,6 +302,15 @@ private:
 
     CommandResponse_t CmdRsp;
 
+    enum RxStatus_t
+    {
+        RXSUCCESS,
+        RXCONTINUE,
+        RXIDLE,
+        RXTIMEOUT,
+        RXINVALID
+    };
+
     // Function protoypes
     void PenUpdate();
     void updateLcdsWithModel();
@@ -325,7 +331,7 @@ private:
     void DoPlot(plotInfo_t *);
     void RePlot(QList<results_t> *);
     bool SaveTubeDataFile();
-    int RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response);
+    void RxPkt(CommandResponse_t *pSendCmdRsp, QByteArray *response, RxStatus_t *pRxStatus);
     void StartUpMachine();
     void StopTheMachine();
     void SendCommand(CommandResponse_t *pCmdRsp, bool txLoad, char rxChar);


### PR DESCRIPTION
Add debug to show the state changes of RxData().

Improve the serial port failure detection in RxData() to make the error reporting clearer between the serial port not being available and the serial port working and then failing.

In RxData(), now first analyse any response before processing the state machine. If a RX timeout occurs, now the "machine" is stopped.

In RxPkt() use an enum based state to replace the #defined states.

Remove the now redundant buf[] from RxData().

Fix the compiler "status" warning by adding a default case in RxData().

In RxPkt(), add the RX status in debug output.

Add a test in SendCommand() to detect when a new TX message is attempted to be sent whilst a TX message is already in the process of being sent.