### PR TITLE
Incorporate the user requests into the main state machine

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -103,7 +103,6 @@ MainWindow::MainWindow(QWidget *parent) :
     doStart = false;
     sendADC = false;
     sendPing = false;
-    newMessage = false;
 
     VaADC=0;
     VsADC=0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -633,24 +633,21 @@ void MainWindow::RxData()
     }
 
     // ---------------------------------------------------
-    if (sendADC == true)
+    // Deal with user requests, communications must be idle
+    if (RxCode == RXIDLE || RxCode == RXSUCCESS)
     {
-        qDebug() << "RxData: Action sendADC";
-        heat = 0;
-        SendADCCommand(&CmdRsp);
-        status = wait_adc;
-        sendADC = false;
-        return;
-    }
-
-    if (sendPing == true)
-    {
-        qDebug() << "RxData: Action sendPing";
-        heat = 0;
-        SendEndMeasurementCommand(&CmdRsp);
-        status = WaitPing;
-        sendPing = false;
-        return;
+        if (sendADC == true)
+        {
+            qDebug() << "RxData: Action sendADC";
+            status = read_adc;
+            sendADC = false;
+        }
+        else if (sendPing == true)
+        {
+            qDebug() << "RxData: Action sendPing";
+            status = send_ping;
+            sendPing = false;
+        }
     }
 
     // ---------------------------------------------------
@@ -660,6 +657,20 @@ void MainWindow::RxData()
 
     switch (status)
     {
+        case send_ping:
+        {
+            heat = 0;
+            SendEndMeasurementCommand(&CmdRsp);
+            status = WaitPing;
+            break;
+        }
+        case read_adc:
+        {
+            heat = 0;
+            SendADCCommand(&CmdRsp);
+            status = wait_adc;
+            break;
+        }
         case Idle:
         {
             time = 0;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -200,7 +200,6 @@ private:
     bool doStart;
     QTimer *timer;
     bool ok;
-    bool newMessage;
     float Vdi;
     float power;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -196,7 +196,6 @@ private:
     int VaStep;
     int curve;
     int heat;
-    bool stop;
     bool doStop;
     bool doStart;
     QTimer *timer;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -196,6 +196,8 @@ private:
     int curve;
     int heat;
     bool stop;
+    bool doStop;
+    bool doStart;
     QTimer *timer;
     bool ok;
     bool newMessage;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -191,6 +191,13 @@ private:
                                       "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping",
                                       "start_sweep_heater"};
 
+    struct interrupted_t
+    {
+        bool cmd;
+        Status_t status;
+        QByteArray response;
+    };
+
     int VsStep;
     int VgStep;
     int VaStep;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -183,13 +183,14 @@ private:
 
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
-                    hold_ack, hold, heat_done, HeatOff, read_adc, send_ping};
+                    hold_ack, hold, heat_done, HeatOff, read_adc, send_ping,
+                    start_sweep_heater, max_state};
     Status_t status;
-    QString status_name[send_ping + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
-                                        "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
-                                        "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping"};
+    QString status_name[max_state] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
+                                      "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
+                                      "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping",
+                                      "start_sweep_heater"};
 
-    int startSweep;
     int VsStep;
     int VgStep;
     int VaStep;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -183,11 +183,11 @@ private:
 
     enum Status_t { WaitPing, Heating, Heating_wait00, Heating_wait_adc,
                     Sweep_set, Sweep_adc, Idle, wait_adc,
-                    hold_ack, hold, heat_done, HeatOff};
+                    hold_ack, hold, heat_done, HeatOff, read_adc, send_ping};
     Status_t status;
-    QString status_name[HeatOff + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
+    QString status_name[send_ping + 1] = {"WaitPing", "Heating", "Heating_wait00", "Heating_wait_adc",
                                         "Sweep_set", "Sweep_adc", "Idle", "wait_adc",
-                                        "hold_ack", "hold", "heat_done", "HeatOff"};
+                                        "hold_ack", "hold", "heat_done", "HeatOff", "read_adc", "send_ping"};
 
     int startSweep;
     int VsStep;


### PR DESCRIPTION
Expand the main state machine to take the user requests into the state machine so that state changes can be managed consistently. The user requests are "start", "stop", "ping" and "read ADC".

Note that sending a communication to the uTracer has to have timeout handling which has been improved by add a RXIDLE state to indicate no communications are in progress. A RXTIMEOUT will cause the state machine to enter the Idle state (stopped).

The "start" and "stop" user requests now transitions the state of the main state machine eliminating a small number of flags.

The "ping" and "read ADC" requests will temporarily interrupt the active state returning to the active state.